### PR TITLE
SPEND-31: Added accounts namespace and updated validators

### DIFF
--- a/FlaskApp/__init__.py
+++ b/FlaskApp/__init__.py
@@ -73,6 +73,8 @@ def create_app():
     api.add_namespace(categories_ns, path='/category')
     from FlaskApp.routes.transactions import ns as transactions_ns
     api.add_namespace(transactions_ns, path='/transaction')
+    from FlaskApp.routes.accounts import ns as accounts_ns
+    api.add_namespace(accounts_ns, path='/account')
     # TODO: Add disconnected blueprints here as needed
 
     #

--- a/FlaskApp/domainmodel/account.py
+++ b/FlaskApp/domainmodel/account.py
@@ -1,46 +1,73 @@
 from __future__ import annotations
 
 from datetime import datetime
-from decimal import Decimal
+import enum
 from typing import List
 from typing import TYPE_CHECKING
 from uuid import UUID
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import User
 
+class AccountType(enum.Enum):
+    CHECKING = 'checking'
+    SAVINGS = 'savings'
+    CREDITCARD = 'credit'
+    LOAN = 'loan'
+    KIWISAVER = 'kiwisaver'
+    INVESTMENT = 'investment'
+    TERMDEPOSIT = 'term_deposit'
+    FOREIGN = 'foreign'
+    TAX = 'tax'
+    REWARDS = 'rewards'
+    WALLET = 'wallet'
 
-class Account:
+class AccountAttribute(enum.Enum):
+    TRANSACTIONS = 'transactions'
+    TRANSFER_TO = 'transfer_to'
+    TRANSFER_FROM = 'transfer_from'
+    PAYMENT_TO = 'payment_to'
+    PAYMENT_FROM = 'payment_from'
+
+
+class Account(ValidatingBaseModel):
     def __init__(self,
                  account_id: UUID,
                  account_name: str,
-                 account_type: str,
+                 account_type: AccountType,
                  formatted_account: str,
-                 attributes: List[str],
+                 attributes: List[AccountAttribute],
                  currency: str,
-                 current_balance: Decimal,
-                 available_balance: Decimal,
+                 current_balance: int,
+                 available_balance: int | None,
                  status: str,
                  created: datetime,
-                 credit_limit: Decimal,
-                 overdrawn: bool,
+                 credit_limit: int | None,
+                 overdrawn: bool | None,
+                 provider_name: str,
+                 provider_logo: str,
 
                  user: 'User',
                  ):
-        self.__id = account_id
-        self.__name = account_name
-        self.__type = account_type
-        self.__formatted_account = formatted_account
-        self.__attributes = attributes
-        self.__currency = currency
-        self.__current_balance = current_balance
-        self.__available_balance = available_balance
-        self.__status = status
-        self.__created = created
-        self.__credit_limit = credit_limit
-        self.__overdrawn = overdrawn
+        # Validate and assign immutable fields directly
+        self.__id = self._validate_uuid(account_id, "account_id")
+        self.__user = self._validate_not_none(user, "user")
+        self.__created = self._validate_datetime(created, "created")
+        self.__current_balance = self._validate_type(current_balance, int, "current_balance")
+        self.__available_balance = self._validate_type(available_balance, int, "available_balance", allow_none=True)
+        self.__overdrawn = self._validate_boolean(overdrawn, "overdrawn", allow_none=True)
+        self.__provider_name = self._validate_string_not_empty(provider_name, "provider_name")
+        self.__provider_logo = self._validate_string_not_empty(provider_logo, "provider_logo")
 
-        self.__user = user
+        # Assign mutable fields via setters for validation
+        self.name = account_name
+        self.type = account_type
+        self.formatted_account = formatted_account
+        self.attributes = attributes
+        self.currency = currency
+        self.status = status
+        self.credit_limit = credit_limit
 
     def __repr__(self):
         return f"Account {self.id}: {self.name}"
@@ -65,9 +92,28 @@ class Account:
     def name(self):
         return self.__name
 
+    @name.setter
+    def name(self, value):
+        self.__name = self._validate_string_not_empty(value, "name")
+
     @property
     def type(self):
         return self.__type
+
+    @type.setter
+    def type(self, value):
+        # Handle coercion from string if necessary, then validate type
+        if isinstance(value, str):
+            try:
+                test_value = AccountType(value)
+                self._validate_type(test_value, AccountType, "type")
+            except ValueError:
+                raise ValueError(f"Invalid AccountType: {value}")
+        elif isinstance(value, AccountType):
+            self._validate_type(value, AccountType, "type")
+        else:
+            raise TypeError(f"Invalid type for AccountType: {type(value).__name__}")
+        self.__type = value
 
     @property
     def formatted_account(self):
@@ -75,17 +121,33 @@ class Account:
 
     @formatted_account.setter
     def formatted_account(self, value):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__formatted_account = value
+        self.__formatted_account = self._validate_string_not_empty(value, "formatted_account")
 
     @property
     def attributes(self):
         return self.__attributes
 
+    @attributes.setter
+    def attributes(self, value):
+        # Validate list and its items
+        self._validate_type(value, list, "attributes")
+        for attr in value:
+            if isinstance(attr, str):
+                try:
+                    AccountAttribute(attr)
+                except ValueError:
+                    raise ValueError(f"Invalid AccountAttribute: {attr}")
+            else:
+                raise TypeError(f"Invalid attribute type in list: {type(attr)}")
+        self.__attributes = value
+
     @property
     def currency(self):
         return self.__currency
+
+    @currency.setter
+    def currency(self, value):
+        self.__currency = self._validate_string_not_empty(value, "currency")
 
     @property
     def current_balance(self):
@@ -101,23 +163,27 @@ class Account:
 
     @credit_limit.setter
     def credit_limit(self, value):
-        if not isinstance(value, Decimal):
-            raise TypeError
-        self.__credit_limit = value
+        self.__credit_limit = self._validate_type(value, int, "credit_limit", allow_none=True)
 
     @property
     def overdrawn(self):
         return self.__overdrawn
 
-    @overdrawn.setter
-    def overdrawn(self, value):
-        if not isinstance(value, bool):
-            raise TypeError
-        self.__overdrawn = value
+    @property
+    def provider_name(self):
+        return self.__provider_name
+
+    @property
+    def provider_logo(self):
+        return self.__provider_logo
 
     @property
     def status(self):
         return self.__status
+
+    @status.setter
+    def status(self, value):
+        self.__status = self._validate_string_not_empty(value, "status")
 
     @property
     def created(self):

--- a/FlaskApp/domainmodel/akahu_account.py
+++ b/FlaskApp/domainmodel/akahu_account.py
@@ -1,36 +1,64 @@
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Dict, Optional
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import Account, User
 
 
-class AkahuAccount():
+class AkahuAccount(ValidatingBaseModel):
     def __init__(self,
                  akahu_account_id: str,
                  authorisation: str,
-                 meta: dict,
+                 meta: Dict,
                  connection_id: str,
+                 connection_type: str,
+                 refreshed: Dict[str, datetime],
+                 refresh_attempt: datetime,
+
+                 account_name: str,
+                 account_type: str,
+                 formatted_account: str | None,
+                 attributes: List[str],
+                 currency: str,
+                 current_balance: int,
+                 available_balance: int | None,
+                 status: str,
+                 created: datetime,
+                 credit_limit: int,
+                 overdrawn: bool,
                  connection_name: str,
                  connection_logo: str,
-                 connection_type: str,
-                 refreshed: dict[str, datetime],
-                 refresh_attempt: datetime,
 
                  user: 'User',
                  account: 'Account',
-                 ):
-        self.__id = akahu_account_id
-        self.__authorisation = authorisation
-        self.__meta = meta
-        self.__connection_id = connection_id
-        self.__connection_name = connection_name
-        self.__connection_logo = connection_logo
-        self.__connection_type = connection_type
-        self.__refreshed = refreshed
-        self.__refresh_attempt = refresh_attempt
-        self.__user = user
-        self.__account = account
+                ):
+        # Validate and assign immutable fields directly
+        self.__id = self._validate_string_not_empty(akahu_account_id, "akahu_account_id")
+        self.__user = self._validate_not_none(user, "user") # Simple check as it's a domain object
+        self.__account = self._validate_not_none(account, "account")
+        self.__created = self._validate_datetime(created, "created")
+
+        # Assign mutable fields via setters for validation
+        self.authorisation = authorisation
+        self.meta = meta
+        self.connection_id = connection_id
+        self.connection_type = connection_type
+        self.refreshed = refreshed
+        self.refresh_attempt = refresh_attempt
+
+        self.name = account_name
+        self.type = account_type
+        self.formatted_account = formatted_account
+        self.attributes = attributes
+        self.currency = currency
+        self.current_balance = current_balance
+        self.available_balance = available_balance
+        self.status = status
+        self.credit_limit = credit_limit
+        self.overdrawn = overdrawn
+        self.connection_name = connection_name
+        self.connection_logo = connection_logo
 
     def __repr__(self):
         return f"AkahuAccount: {self.account}"
@@ -48,36 +76,36 @@ class AkahuAccount():
         return self.__id
 
     @property
-    def user(self):
-        return self.__user
+    def authorisation(self):
+        return self.__authorisation
 
-    @property
-    def account(self):
-        return self.__account
+    @authorisation.setter
+    def authorisation(self, value):
+        self.__authorisation = self._validate_string_not_empty(value, "authorisation")
 
     @property
     def meta(self):
         return self.__meta
 
-    @property
-    def authorisation(self):
-        return self.__authorisation
+    @meta.setter
+    def meta(self, value):
+        self.__meta = self._validate_dict(value, "meta")
 
     @property
     def connection_id(self):
         return self.__connection_id
 
-    @property
-    def connection_name(self):
-        return self.__connection_name
-
-    @property
-    def connection_logo(self):
-        return self.__connection_logo
+    @connection_id.setter
+    def connection_id(self, value):
+        self.__connection_id = self._validate_string_not_empty(value, "connection_id")
 
     @property
     def connection_type(self):
         return self.__connection_type
+
+    @connection_type.setter
+    def connection_type(self, value):
+        self.__connection_type = self._validate_string_not_empty(value, "connection_type")
 
     @property
     def refreshed(self):
@@ -85,9 +113,91 @@ class AkahuAccount():
 
     @refreshed.setter
     def refreshed(self, value):
-        if not isinstance(value, datetime):
-            raise TypeError
-        self.__refreshed = value
+        self.__refreshed = self._validate_dict(value, "refreshed")
+
+    @property
+    def name(self):
+        return self.__name
+
+    @name.setter
+    def name(self, value):
+        self.__name = self._validate_string_not_empty(value, "name")
+
+    @property
+    def type(self):
+        return self.__type
+
+    @type.setter
+    def type(self, value):
+        self.__type = self._validate_string_not_empty(value, "type")
+
+    @property
+    def formatted_account(self):
+        return self.__formatted_account
+
+    @formatted_account.setter
+    def formatted_account(self, value):
+        self.__formatted_account = self._validate_string_not_empty(value, "formatted_account", allow_none=True)
+
+    @property
+    def attributes(self):
+        return self.__attributes
+
+    @attributes.setter
+    def attributes(self, value):
+        self.__attributes = self._validate_list_of_strings(value, "attributes")
+
+    @property
+    def currency(self):
+        return self.__currency
+
+    @currency.setter
+    def currency(self, value):
+        self.__currency = self._validate_string_not_empty(value, "currency")
+
+    @property
+    def current_balance(self):
+        return self.__current_balance
+
+    @current_balance.setter
+    def current_balance(self, value):
+        self.__current_balance = self._validate_type(value, int, "current_balance")
+
+    @property
+    def available_balance(self):
+        return self.__available_balance
+
+    @available_balance.setter
+    def available_balance(self, value):
+        self.__available_balance = self._validate_type(value, int, "available_balance", allow_none=True)
+
+    @property
+    def status(self):
+        return self.__status
+
+    @status.setter
+    def status(self, value):
+        self.__status = self._validate_string_not_empty(value, "status")
+
+    @property
+    def created(self):
+        return self.__created
+
+    @property
+    def credit_limit(self):
+        return self.__credit_limit
+
+    @credit_limit.setter
+    def credit_limit(self, value):
+        self.__credit_limit = self._validate_type(value, int, "credit_limit")
+
+    @property
+    def overdrawn(self):
+        return self.__overdrawn
+
+    @overdrawn.setter
+    def overdrawn(self, value):
+        self.__overdrawn = self._validate_boolean(value, "overdrawn")
 
     @property
     def refresh_attempt(self):
@@ -95,6 +205,29 @@ class AkahuAccount():
 
     @refresh_attempt.setter
     def refresh_attempt(self, value):
-        if not isinstance(value, datetime):
-            raise TypeError
-        self.__refresh_attempt = value
+        self.__refresh_attempt = self._validate_datetime(value, "refresh_attempt")
+
+    @property
+    def connection_name(self):
+        return self.__connection_name
+
+    @connection_name.setter
+    def connection_name(self, value):
+        self.__connection_name = self._validate_string_not_empty(value, "connection_name")
+
+    @property
+    def connection_logo(self):
+        return self.__connection_logo
+
+    @connection_logo.setter
+    def connection_logo(self, value):
+        self.__connection_logo = self._validate_string_not_empty(value, "connection_logo")
+
+    @property
+    def user(self):
+        return self.__user
+
+    @property
+    def account(self):
+        return self.__account
+

--- a/FlaskApp/domainmodel/akahu_category.py
+++ b/FlaskApp/domainmodel/akahu_category.py
@@ -1,18 +1,20 @@
 from typing import TYPE_CHECKING, List
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import AkahuTransaction
 
 
-class AkahuCategory:
+class AkahuCategory(ValidatingBaseModel):
     def __init__(self,
                  nzfcc_id: str,
                  nzfcc_name: str,
                  groups: dict[str, dict[str, str]],
                  ):
-        self.__id = nzfcc_id
-        self.__name = nzfcc_name
-        self.__groups = groups
+        # Validate and assign immutable fields
+        self.__id = self._validate_string_not_empty(nzfcc_id, "nzfcc_id")
+        self.__name = self._validate_string_not_empty(nzfcc_name, "nzfcc_name")
+        self.__groups = self._validate_dict(groups, "groups")
         self.__transactions: List['AkahuTransaction'] = []
 
     def __repr__(self):

--- a/FlaskApp/domainmodel/akahu_merchant.py
+++ b/FlaskApp/domainmodel/akahu_merchant.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import Merchant
 
 
-class AkahuMerchant:
+class AkahuMerchant(ValidatingBaseModel):
     def __init__(self,
                  akahu_merchant_id: str,
                  nzbn: str | None,
@@ -12,11 +13,12 @@ class AkahuMerchant:
                  website: str | None,
                  logo: str | None,
                  ):
-        self.__id = akahu_merchant_id
-        self.__nzbn = nzbn
-        self.__name = name
-        self.__website = website
-        self.__logo = logo
+        # Validate and assign immutable fields
+        self.__id = self._validate_string_not_empty(akahu_merchant_id, "akahu_merchant_id")
+        self.__nzbn = self._validate_string_not_empty(nzbn, "nzbn", allow_none=True)
+        self.__name = self._validate_string_not_empty(name, "name")
+        self.__website = self._validate_string_not_empty(website, "website", allow_none=True)
+        self.__logo = self._validate_string_not_empty(logo, "logo", allow_none=True)
 
 
     def __repr__(self):

--- a/FlaskApp/domainmodel/akahu_transaction.py
+++ b/FlaskApp/domainmodel/akahu_transaction.py
@@ -1,11 +1,15 @@
 from datetime import datetime
 from typing import TYPE_CHECKING
+from FlaskApp.domainmodel.base import ValidatingBaseModel
+
+from FlaskApp.domainmodel.akahu_merchant import AkahuMerchant
+from FlaskApp.domainmodel.akahu_category import AkahuCategory
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import AkahuCategory, AkahuAccount, AkahuMerchant, Transaction, User
 
 
-class AkahuTransaction:
+class AkahuTransaction(ValidatingBaseModel):
     def __init__(
             self,
             akahu_transaction_id: str,
@@ -13,23 +17,39 @@ class AkahuTransaction:
             updated: datetime,
             meta: dict,
 
+            amount: int,
+            date: datetime,
+            description: str,
+            balance: int | None,
+            type: str | None,
+            pending: bool,
+
             user: 'User',
             transaction: 'Transaction',
             akahu_account: 'AkahuAccount',
             akahu_category: 'AkahuCategory | None',
             akahu_merchant: 'AkahuMerchant | None'
     ):
-        self.__id = akahu_transaction_id
-        # Akahu hash is deprecated
-        self.__created = created
-        self.__updated = updated
-        self.__meta = meta
+        # Validate and assign immutable fields
+        self.__id = self._validate_string_not_empty(akahu_transaction_id, "akahu_transaction_id")
+        self.__transaction = self._validate_not_none(transaction, "transaction")
+        self.__akahu_account = self._validate_not_none(akahu_account, "akahu_account")
+        self.__user = self._validate_not_none(user, "user")
 
-        self.__transaction = transaction
-        self.__akahu_account = akahu_account
-        self.__akahu_category = akahu_category
-        self.__akahu_merchant = akahu_merchant
-        self.__user = user
+        # Assign mutable fields via setters
+        self.created = created
+        self.updated = updated
+        self.meta = meta
+
+        self.amount = amount
+        self.date = date
+        self.description = description
+        self.balance = balance
+        self.type = type
+        self.pending = pending
+
+        self.akahu_category = akahu_category
+        self.akahu_merchant = akahu_merchant
 
     def __repr__(self):
         return f"<AkahuTransaction: {self.transaction}>"
@@ -50,13 +70,73 @@ class AkahuTransaction:
     def created(self):
         return self.__created
 
+    @created.setter
+    def created(self, value):
+        self.__created = self._validate_datetime(value, "created")
+
     @property
     def updated(self):
         return self.__updated
 
+    @updated.setter
+    def updated(self, value):
+        self.__updated = self._validate_datetime(value, "updated")
+
     @property
     def meta(self):
         return self.__meta
+
+    @meta.setter
+    def meta(self, value):
+        self.__meta = self._validate_dict(value, "meta")
+
+    @property
+    def amount(self):
+        return self.__amount
+
+    @amount.setter
+    def amount(self, value):
+        self.__amount = self._validate_type(value, int, "amount")
+
+    @property
+    def date(self):
+        return self.__date
+
+    @date.setter
+    def date(self, value):
+        self.__date = self._validate_datetime(value, "date")
+
+    @property
+    def description(self):
+        return self.__description
+
+    @description.setter
+    def description(self, value):
+        self.__description = self._validate_string_not_empty(value, "description")
+
+    @property
+    def balance(self):
+        return self.__balance
+
+    @balance.setter
+    def balance(self, value):
+        self.__balance = self._validate_type(value, int, "balance", allow_none=True)
+
+    @property
+    def type(self):
+        return self.__type
+
+    @type.setter
+    def type(self, value):
+        self.__type = self._validate_string_not_empty(value, "type", allow_none=True)
+
+    @property
+    def pending(self):
+        return self.__pending
+
+    @pending.setter
+    def pending(self, value):
+        self.__pending = self._validate_boolean(value, "pending")
 
     @property
     def user(self):
@@ -74,6 +154,20 @@ class AkahuTransaction:
     def akahu_category(self):
         return self.__akahu_category
 
+    @akahu_category.setter
+    def akahu_category(self, value):
+        # Specific check for domain object type
+        if value is not None and not isinstance(value, AkahuCategory):
+             raise TypeError(f"akahu_category must be of type AkahuCategory, got {type(value).__name__}.")
+        self.__akahu_category = value
+
     @property
     def akahu_merchant(self):
         return self.__akahu_merchant
+
+    @akahu_merchant.setter
+    def akahu_merchant(self, value):
+        # Specific check for domain object type
+        if value is not None and not isinstance(value, AkahuMerchant):
+             raise TypeError(f"akahu_merchant must be of type AkahuMerchant, got {type(value).__name__}.")
+        self.__akahu_merchant = value

--- a/FlaskApp/domainmodel/base.py
+++ b/FlaskApp/domainmodel/base.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, List, Dict, TypeVar, Union
+import uuid
+
+T = TypeVar('T')
+
+class ValidatingBaseModel:
+    """Base class providing common validation helper methods for domain models."""
+
+    def _validate_not_none(self, value: T, field_name: str) -> T:
+        """Ensures a value is not None."""
+        if value is None:
+            raise ValueError(f"{field_name} cannot be None.")
+        return value
+
+    def _validate_type(self, value: Any, expected_type: type, field_name: str, allow_none: bool = False) -> Any:
+        """Ensures a value is of a specific type, optionally allowing None."""
+        if allow_none and value is None:
+            return value
+        if not isinstance(value, expected_type):
+            raise TypeError(f"{field_name} must be of type {expected_type.__name__}, got {type(value).__name__}.")
+        return value
+
+    def _validate_string_not_empty(self, value: str, field_name: str, max_length: int = None, allow_none: bool = False) -> Union[str, None]:
+        """Ensures a string is not empty, optionally allowing None and checking max length."""
+        value = self._validate_type(value, str, field_name, allow_none)
+        if value is None:
+            return None
+        if not value.strip():
+            raise ValueError(f"{field_name} cannot be an empty string.")
+        if max_length is not None and len(value) > max_length:
+            raise ValueError(f"{field_name} exceeds maximum length of {max_length}.")
+        return value
+
+    def _validate_decimal_non_negative(self, value: Decimal, field_name: str, allow_none: bool = False) -> Union[Decimal, None]:
+        """Ensures a Decimal is non-negative, optionally allowing None."""
+        value = self._validate_type(value, Decimal, field_name, allow_none)
+        if value is None:
+            return None
+        if value < 0:
+            raise ValueError(f"{field_name} cannot be negative.")
+        return value
+
+    def _validate_list_of_strings(self, value: List[str], field_name: str, allow_none: bool = False) -> Union[List[str], None]:
+        """Ensures a value is a list of strings, optionally allowing None."""
+        value = self._validate_type(value, list, field_name, allow_none)
+        if value is None:
+            return None
+        if not all(isinstance(item, str) for item in value):
+            raise TypeError(f"{field_name} must be a list of strings.")
+        return value
+
+    def _validate_dict(self, value: Dict, field_name: str, allow_none: bool = False) -> Union[Dict, None]:
+        """Ensures a value is a dict, optionally allowing None."""
+        return self._validate_type(value, dict, field_name, allow_none)
+
+    def _validate_datetime(self, value: datetime, field_name: str, allow_none: bool = False) -> Union[datetime, None]:
+        """Ensures a value is a datetime object, optionally allowing None."""
+        return self._validate_type(value, datetime, field_name, allow_none)
+
+    def _validate_boolean(self, value: bool, field_name: str, allow_none: bool = False) -> Union[bool, None]:
+        """Ensures a value is a boolean, optionally allowing None."""
+        return self._validate_type(value, bool, field_name, allow_none)
+
+    def _validate_float(self, value: float, field_name: str, allow_none: bool = False) -> Union[float, None]:
+        """Ensures a value is a float, optionally allowing None."""
+        return self._validate_type(value, float, field_name, allow_none)
+
+    def _validate_uuid(self, value: uuid.UUID, field_name: str, allow_none: bool = False) -> Union[uuid.UUID, None]:
+        """Ensures a value is a UUID object, optionally allowing None."""
+        return self._validate_type(value, uuid.UUID, field_name, allow_none)

--- a/FlaskApp/domainmodel/category.py
+++ b/FlaskApp/domainmodel/category.py
@@ -1,34 +1,43 @@
 from datetime import datetime
+import enum
 from typing import TYPE_CHECKING
 from uuid import UUID
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import User
 
 
-class Category:
+class CategoryType(enum.Enum):
+    EXPENSE = 'expense'
+    INCOME = 'income'
+    ALL = 'all'
+
+class Category(ValidatingBaseModel):
     def __init__(self,
                  category_id: UUID,
                  name: str,
                  description: str,
                  colour: str,
                  icon: str | None,
-                 category_type: str,
+                 category_type: CategoryType,
                  created: datetime,
 
                  parent_category: 'Category | None',
                  user: 'User'
                  ):
-        self.__id = category_id
-        self.__name = name
-        self.__description = description
-        self.__colour = colour
-        self.__icon = icon
-        self.__type = category_type
-        self.__created = created
+        # Validate and assign immutable fields
+        self.__id = self._validate_uuid(category_id, "category_id")
+        self.__created = self._validate_datetime(created, "created")
+        self.__user = self._validate_not_none(user, "user")
 
-        self.__user = user
-        self.__parent_category = parent_category
+        # Assign mutable fields via setters
+        self.name = name
+        self.description = description
+        self.colour = colour
+        self.icon = icon
+        self.type = category_type
+        self.parent_category = parent_category
 
     def __repr__(self):
         return f"<Category {self.id}: {self.name}>"
@@ -51,9 +60,7 @@ class Category:
 
     @name.setter
     def name(self, value):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__name = value
+        self.__name = self._validate_string_not_empty(value, "name")
 
     @property
     def description(self):
@@ -61,9 +68,7 @@ class Category:
 
     @description.setter
     def description(self, value):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__description = value
+        self.__description = self._validate_type(value, str, "description")
 
     @property
     def colour(self):
@@ -71,9 +76,7 @@ class Category:
 
     @colour.setter
     def colour(self, value):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__colour = value
+        self.__colour = self._validate_string_not_empty(value, "colour")
 
     @property
     def icon(self):
@@ -81,9 +84,7 @@ class Category:
 
     @icon.setter
     def icon(self, value):
-        if not isinstance(value, str | None):
-            raise TypeError
-        self.__icon = value
+        self.__icon = self._validate_string_not_empty(value, "icon", allow_none=True)
 
     @property
     def type(self):
@@ -91,8 +92,16 @@ class Category:
 
     @type.setter
     def type(self, value):
-        if not isinstance(value, str):
-            raise TypeError
+        if isinstance(value, str):
+            try:
+                test_value = CategoryType(value)
+                self._validate_type(test_value, CategoryType, "type")
+            except ValueError:
+                raise ValueError(f"Invalid CategoryType: {value}")
+        elif isinstance(value, CategoryType):
+            self._validate_type(value, CategoryType, "type")
+        else:
+            raise TypeError(f"Invalid type for CategoryType: {type(value).__name__}")
         self.__type = value
 
     @property
@@ -105,8 +114,8 @@ class Category:
 
     @parent_category.setter
     def parent_category(self, value):
-        if not isinstance(value, Category | None):
-            raise TypeError
+        if value is not None and not isinstance(value, Category):
+            raise TypeError(f"parent_category must be a Category object, got {type(value).__name__}")
         self.__parent_category = value
 
     @property

--- a/FlaskApp/domainmodel/external_identity.py
+++ b/FlaskApp/domainmodel/external_identity.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 
-class ExternalIdentity:
+class ExternalIdentity(ValidatingBaseModel):
     def __init__(
             self,
             provider: str,  # 'google', 'apple', 'akahu'
@@ -12,13 +13,14 @@ class ExternalIdentity:
             meta: dict,
             connected_at: datetime,
     ):
-        self.__provider = provider
-        self.__external_id = external_id
-        self.__email = email
-        self.__name = name
-        self.__avatar_url = avatar_url
-        self.__meta = meta
-        self.__connected_at = connected_at
+        # Validate and assign fields
+        self.__provider = self._validate_string_not_empty(provider, "provider")
+        self.__external_id = self._validate_string_not_empty(external_id, "external_id")
+        self.__email = self._validate_string_not_empty(email, "email", allow_none=True)
+        self.__name = self._validate_string_not_empty(name, "name", allow_none=True)
+        self.__avatar_url = self._validate_string_not_empty(avatar_url, "avatar_url", allow_none=True)
+        self.__meta = self._validate_dict(meta, "meta")
+        self.__connected_at = self._validate_datetime(connected_at, "connected_at")
 
     def __repr__(self):
         return f"<ExternalIdentity: {self.provider}"

--- a/FlaskApp/domainmodel/merchant.py
+++ b/FlaskApp/domainmodel/merchant.py
@@ -1,11 +1,12 @@
 from typing import TYPE_CHECKING
 from uuid import UUID
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import User
 
 
-class Merchant:
+class Merchant(ValidatingBaseModel):
     def __init__(self,
                  merchant_id: UUID,
                  nzbn: str | None,
@@ -16,13 +17,15 @@ class Merchant:
                  user: 'User'
                  ):
 
-        self.__id = merchant_id
-        self.__nzbn = nzbn
-        self.__name = name
-        self.__website = website
-        self.__logo = logo
+        # Validate and assign immutable fields
+        self.__id = self._validate_uuid(merchant_id, "merchant_id")
+        self.__user = self._validate_not_none(user, "user")
 
-        self.__user = user
+        # Assign mutable fields via setters
+        self.name = name
+        self.nzbn = nzbn
+        self.website = website
+        self.logo = logo
 
     def __repr__(self):
         return f"<Merchant {self.id}: {self.name}>"
@@ -47,15 +50,17 @@ class Merchant:
     def nzbn(self):
         return self.__nzbn
 
+    @nzbn.setter
+    def nzbn(self, value):
+        self.__nzbn = self._validate_string_not_empty(value, "nzbn", allow_none=True)
+
     @property
     def name(self):
         return self.__name
 
     @name.setter
     def name(self, value: str):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__name = value
+        self.__name = self._validate_string_not_empty(value, "name")
 
     @property
     def website(self):
@@ -63,9 +68,7 @@ class Merchant:
 
     @website.setter
     def website(self, value):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__website = value
+        self.__website = self._validate_string_not_empty(value, "website", allow_none=True)
 
     @property
     def logo(self):
@@ -73,6 +76,4 @@ class Merchant:
 
     @logo.setter
     def logo(self, value):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__logo = value
+        self.__logo = self._validate_string_not_empty(value, "logo", allow_none=True)

--- a/FlaskApp/domainmodel/transaction.py
+++ b/FlaskApp/domainmodel/transaction.py
@@ -1,21 +1,41 @@
 from datetime import datetime
-from decimal import Decimal
+import enum
 from typing import TYPE_CHECKING
 from uuid import UUID
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import Category, Account, User, Merchant
 
+# ... (enum definitions remain same)
 
-class Transaction:
+
+class TransactionType(enum.Enum):
+    CREDIT = 'credit'
+    DEBIT = 'debit'
+    PAYMENT = 'payment'
+    TRANSFER = 'transfer'
+    STANDING_ORDER = 'standing order'
+    EFTPOS = 'eftpos'
+    INTEREST = 'interest'
+    FEE = 'fee'
+    TAX = 'tax'
+    CREDIT_CARD = 'credit card'
+    DIRECT_CREDIT = 'direct credit'
+    DIRECT_DEBIT = 'direct debit'
+    ATM = 'atm'
+    LOAN = 'loan'
+
+
+class Transaction(ValidatingBaseModel):
     def __init__(
             self,
             transaction_id: UUID,
-            amount: Decimal,
+            amount: int,
             date: datetime,
             description: str,
-            balance: Decimal | None,
-            transaction_type: str,
+            balance: int | None,
+            transaction_type: TransactionType,
             status: str,
             pending: bool,
             created: datetime,
@@ -27,22 +47,25 @@ class Transaction:
             category: 'Category | None',
             merchant: 'Merchant | None',
     ):
-        self.__id = transaction_id
-        self.__amount = amount
-        self.__date = date
-        self.__description = description
-        self.__balance = balance
-        self.__type = transaction_type
-        self.__status = status
-        self.__pending = pending
-        self.__created = created
-        self.__latitude = latitude
-        self.__longitude = longitude
+        # Validate and assign immutable fields
+        self.__id = self._validate_uuid(transaction_id, "transaction_id")
+        self.__created = self._validate_datetime(created, "created")
+        self.__user = self._validate_not_none(user, "user")
 
-        self.__user = user
-        self.__account = account
-        self.__category = category
-        self.__merchant = merchant
+        # Assign mutable fields via setters
+        self.amount = amount
+        self.date = date
+        self.description = description
+        self.balance = balance
+        self.type = transaction_type
+        self.status = status
+        self.pending = pending
+        self.latitude = latitude
+        self.longitude = longitude
+
+        self.account = account
+        self.category = category
+        self.merchant = merchant
 
     def __repr__(self):
         return f"<Transaction {self.id}: {self.description}>"
@@ -65,9 +88,7 @@ class Transaction:
 
     @amount.setter
     def amount(self, value):
-        if not isinstance(value, Decimal):
-            raise TypeError
-        self.__amount = value
+        self.__amount = self._validate_type(value, int, "amount")
 
     @property
     def date(self):
@@ -75,9 +96,7 @@ class Transaction:
 
     @date.setter
     def date(self, value):
-        if not isinstance(value, datetime):
-            raise TypeError
-        self.__date = value
+        self.__date = self._validate_datetime(value, "date")
 
     @property
     def description(self):
@@ -85,9 +104,7 @@ class Transaction:
 
     @description.setter
     def description(self, value):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__description = value
+        self.__description = self._validate_string_not_empty(value, "description")
 
     @property
     def balance(self):
@@ -95,9 +112,7 @@ class Transaction:
 
     @balance.setter
     def balance(self, value):
-        if value is not None and not isinstance(value, Decimal):
-            raise TypeError
-        self.__balance = value
+        self.__balance = self._validate_type(value, int, "balance", allow_none=True)
 
     @property
     def type(self):
@@ -105,8 +120,16 @@ class Transaction:
 
     @type.setter
     def type(self, value):
-        if not isinstance(value, str):
-            raise TypeError
+        if isinstance(value, str):
+            try:
+                test_value = TransactionType(value)
+                self._validate_type(test_value, TransactionType, "type")
+            except ValueError:
+                raise ValueError(f"Invalid TransactionType: {value}")
+        elif isinstance(value, TransactionType):
+            self._validate_type(value, TransactionType, "type")
+        else:
+            raise TypeError(f"Invalid type for TransactionType: {type(value).__name__}")
         self.__type = value
 
     @property
@@ -115,9 +138,7 @@ class Transaction:
 
     @status.setter
     def status(self, value):
-        if not isinstance(value, str):
-            raise TypeError
-        self.__status = value
+        self.__status = self._validate_string_not_empty(value, "status")
 
     @property
     def pending(self):
@@ -125,9 +146,7 @@ class Transaction:
 
     @pending.setter
     def pending(self, value):
-        if not isinstance(value, bool):
-            raise TypeError
-        self.__pending = value
+        self.__pending = self._validate_boolean(value, "pending")
 
     @property
     def created(self):
@@ -139,9 +158,7 @@ class Transaction:
 
     @latitude.setter
     def latitude(self, value):
-        if value is not None and not isinstance(value, float):
-            raise TypeError
-        self.__latitude = value
+        self.__latitude = self._validate_float(value, "latitude", allow_none=True)
 
     @property
     def longitude(self):
@@ -149,9 +166,7 @@ class Transaction:
 
     @longitude.setter
     def longitude(self, value):
-        if value is not None and not isinstance(value, float):
-            raise TypeError
-        self.__longitude = value
+        self.__longitude = self._validate_float(value, "longitude", allow_none=True)
 
     @property
     def user(self):
@@ -163,8 +178,10 @@ class Transaction:
 
     @account.setter
     def account(self, value: 'Account'):
+        # Specific check for domain object
+        from FlaskApp.domainmodel.account import Account
         if not isinstance(value, Account):
-            raise TypeError
+            raise TypeError(f"account must be an Account object, got {type(value).__name__}")
         self.__account = value
 
     @property
@@ -173,8 +190,10 @@ class Transaction:
 
     @category.setter
     def category(self, value: 'Category | None'):
+        # Specific check for domain object
+        from FlaskApp.domainmodel.category import Category
         if value is not None and not isinstance(value, Category):
-            raise TypeError
+            raise TypeError(f"category must be a Category object, got {type(value).__name__}")
         self.__category = value
 
     @property
@@ -183,6 +202,8 @@ class Transaction:
 
     @merchant.setter
     def merchant(self, value: 'Merchant | None'):
+        # Specific check for domain object
+        from FlaskApp.domainmodel.merchant import Merchant
         if value is not None and not isinstance(value, Merchant):
-            raise TypeError
+            raise TypeError(f"merchant must be a Merchant object, got {type(value).__name__}")
         self.__merchant = value

--- a/FlaskApp/domainmodel/upload.py
+++ b/FlaskApp/domainmodel/upload.py
@@ -1,12 +1,19 @@
 from datetime import datetime
+import enum
 from typing import TYPE_CHECKING
 from uuid import UUID
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 if TYPE_CHECKING:
     from FlaskApp.domainmodel import User
 
 
-class Upload:
+class SupportedBank(enum.Enum):
+    ANZ = 'anz'
+    KIWIBANK = 'kiwibank'
+
+
+class Upload(ValidatingBaseModel):
     def __init__(self,
                  upload_id: UUID,
                  created: datetime,
@@ -18,13 +25,20 @@ class Upload:
                  user: 'User'
                  ):
 
-        self.__id = upload_id
-        self.__created = created
+        # Validate and assign fields
+        self.__id = self._validate_uuid(upload_id, "upload_id")
+        self.__created = self._validate_datetime(created, "created")
+        test_bank = SupportedBank(bank)
+        _ = self._validate_type(test_bank, SupportedBank, "bank") # Validate bank
         self.__bank = bank
-        self.__file_name = file_name
+        self.__file_name = self._validate_string_not_empty(file_name, "file_name")
+        self.__status = self._validate_string_not_empty(status, "status")
+        # Validate list of UUIDs
+        self._validate_type(transaction_ids, list, "transaction_ids")
+        for tid in transaction_ids:
+            self._validate_uuid(tid, "transaction_id in list")
         self.__transaction_ids = transaction_ids
-        self.__status = status
-        self.__user = user
+        self.__user = self._validate_not_none(user, "user")
 
     def __repr__(self):
         return f"<Upload {self.id}: {self.file_name}>"
@@ -66,6 +80,5 @@ class Upload:
         return self.__transaction_ids
 
     def add_transaction(self, transaction_id: UUID):
-        if not isinstance(transaction_id, UUID):
-            raise TypeError
+        self._validate_uuid(transaction_id, "transaction_id")
         self.__transaction_ids.append(transaction_id)

--- a/FlaskApp/domainmodel/user.py
+++ b/FlaskApp/domainmodel/user.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, List
 from uuid import UUID
+from FlaskApp.domainmodel.base import ValidatingBaseModel
 
 import bcrypt
 
@@ -12,7 +13,7 @@ from FlaskApp.domainmodel.account import Account
 from FlaskApp.domainmodel.category import Category
 
 
-class User:
+class User(ValidatingBaseModel):
     def __init__(self,
                  user_id: UUID,
                  email: str,
@@ -23,13 +24,14 @@ class User:
                  last_active: datetime | None,  # None if never logged in
                  ):
 
-        self.__id = user_id
-        self.__email = email
-        self.__name = name
-        self.__password = password
-        self.__status = status
-        self.__created = created
-        self.__last_active = last_active
+        # Validate and assign fields
+        self.__id = self._validate_uuid(user_id, "user_id")
+        self.__email = self._validate_string_not_empty(email, "email")
+        self.__name = self._validate_string_not_empty(name, "name")
+        self.__password = self._validate_string_not_empty(password, "password", allow_none=True)
+        self.__status = self._validate_string_not_empty(status, "status")
+        self.__created = self._validate_datetime(created, "created")
+        self.__last_active = self._validate_datetime(last_active, "last_active", allow_none=True)
 
         self.__accounts: List['Account'] = []
         self.__categories: List['Category'] = []

--- a/FlaskApp/infra/db/mappers/account_mapper.py
+++ b/FlaskApp/infra/db/mappers/account_mapper.py
@@ -19,6 +19,8 @@ def account_orm_to_domain(
         created=tx.created,
         credit_limit=tx.credit_limit,
         overdrawn=tx.overdrawn,
+        provider_name=tx.provider_name,
+        provider_logo=tx.provider_logo,
         user=user,
     )
 
@@ -38,5 +40,7 @@ def account_domain_to_orm(
         created=tx.created,
         credit_limit=tx.credit_limit,
         overdrawn=tx.overdrawn,
-        user_id=tx.user.id
+        user_id=tx.user.id,
+        provider_name=tx.provider_name,
+        provider_logo=tx.provider_logo,
     )

--- a/FlaskApp/infra/db/mappers/akahu_mapper.py
+++ b/FlaskApp/infra/db/mappers/akahu_mapper.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from FlaskApp.domainmodel import AkahuAccount, AkahuCategory, AkahuMerchant, AkahuTransaction, \
     User, Merchant
 from FlaskApp.infra.db.mappers.account_mapper import account_orm_to_domain
@@ -16,10 +18,17 @@ def akahu_transaction_orm_to_domain(
         updated=tx.updated,
         meta=tx.meta,
 
+        amount=tx.amount,
+        date=tx.date,
+        description=tx.description,
+        balance=tx.balance,
+        type=tx.type,
+        pending=tx.pending,
+
         user=user,
         transaction=transaction_orm_to_domain(tx.transaction, user=user),
         akahu_account=akahu_account_orm_to_domain(tx.akahu_account, user=user),
-        akahu_category=akahu_category_orm_to_domain(tx.akahu_category, user=user) if tx.akahu_category else None,
+        akahu_category=akahu_category_orm_to_domain(tx.akahu_category) if tx.akahu_category else None,
         akahu_merchant=akahu_merchant_orm_to_domain(tx.akahu_merchant) if tx.akahu_merchant else None,
     )
 
@@ -32,6 +41,14 @@ def akahu_transaction_domain_to_orm(
         created=tx.created,
         updated=tx.updated,
         meta=tx.meta,
+
+        amount=tx.amount,
+        date=tx.date,
+        description=tx.description,
+        balance=tx.balance,
+        type=tx.type,
+        pending=tx.pending,
+
         user_id=tx.user.id,
         transaction_id=tx.transaction.id,
         akahu_account_id=tx.akahu_account.id,
@@ -69,17 +86,28 @@ def akahu_account_orm_to_domain(
         authorisation=tx.authorisation,
         meta=tx.meta,
         connection_id=tx.connection_id,
+        connection_type=tx.connection_type,
+        refreshed={k: datetime.fromisoformat(v) for k, v in tx.refreshed.items()},
+        refresh_attempt=tx.refresh_attempt,
+        account_name=tx.name,
+        account_type=tx.type,
+        formatted_account=tx.formatted_account,
+        attributes=[a.attribute for a in tx.attributes],
+        currency=tx.currency,
+        current_balance=tx.current_balance,
+        available_balance=tx.available_balance,
+        status=tx.status,
+        created=tx.created,
+        credit_limit=tx.credit_limit,
+        overdrawn=tx.overdrawn,
         connection_name=tx.connection_name,
         connection_logo=tx.connection_logo,
-        connection_type=tx.connection_type,
-        refreshed=tx.refreshed,
-        refresh_attempt=tx.refresh_attempt,
         user=user,
         account=account_orm_to_domain(tx.account, user=user),
     )
 
 
-def akahu_account_domain_to_orm(
+def  akahu_account_domain_to_orm(
         tx: AkahuAccount,
 ) -> AkahuAccountORM:
     return AkahuAccountORM(
@@ -87,11 +115,21 @@ def akahu_account_domain_to_orm(
         authorisation=tx.authorisation,
         meta=tx.meta,
         connection_id=tx.connection_id,
+        connection_type=tx.connection_type,
+        refreshed={k: v.isoformat() for k, v in tx.refreshed.items()},
+        refresh_attempt=tx.refresh_attempt,
+        name=tx.name,
+        type=tx.type,
+        formatted_account=tx.formatted_account,
+        currency=tx.currency,
+        credit_limit=tx.credit_limit,
+        overdrawn=tx.overdrawn,
+        status=tx.status,
+        created=tx.created,
+        current_balance=tx.current_balance,
+        available_balance=tx.available_balance,
         connection_name=tx.connection_name,
         connection_logo=tx.connection_logo,
-        connection_type=tx.connection_type,
-        refreshed=tx.refreshed,
-        refresh_attempt=tx.refresh_attempt,
         user_id=tx.user.id,
         account_id=tx.account.id,
     )

--- a/FlaskApp/infra/db/orm/__init__.py
+++ b/FlaskApp/infra/db/orm/__init__.py
@@ -1,5 +1,5 @@
 from FlaskApp.infra.db.orm.account_orm import AccountORM, AccountAttributeORM
-from FlaskApp.infra.db.orm.akahu_account_orm import AkahuAccountORM
+from FlaskApp.infra.db.orm.akahu_account_orm import AkahuAccountORM, AkahuAccountAttributeORM
 from FlaskApp.infra.db.orm.akahu_category_orm import AkahuCategoryORM
 from FlaskApp.infra.db.orm.akahu_merchant_orm import AkahuMerchantORM
 from FlaskApp.infra.db.orm.akahu_transaction_orm import AkahuTransactionORM

--- a/FlaskApp/infra/db/orm/account_orm.py
+++ b/FlaskApp/infra/db/orm/account_orm.py
@@ -1,9 +1,23 @@
 import uuid
 
-from sqlalchemy import UUID, Column, DateTime, ForeignKey, Numeric, String, Boolean
-from sqlalchemy.orm import relationship
-
+from sqlalchemy import UUID, BigInteger, Column, DateTime, ForeignKey, Numeric, String, Boolean, and_, select, or_, func
+from sqlalchemy.orm import relationship, column_property
+from FlaskApp.infra.db.orm.transaction_orm import TransactionORM
 from FlaskApp.infra.db.base import Base
+from FlaskApp.domainmodel.account import AccountType
+
+
+# Module-level function for balance expression
+def balance_expr(account_id_col):
+    return (
+        select(func.coalesce(func.sum(TransactionORM.amount), 0))
+        .where(
+            TransactionORM.account_id == account_id_col,
+            TransactionORM.status.in_(["active", "hidden_active"]),
+        )
+        .correlate_except(TransactionORM)
+        .scalar_subquery()
+    )
 
 
 class AccountORM(Base):
@@ -14,13 +28,50 @@ class AccountORM(Base):
     type = Column(String, nullable=False)
     formatted_account = Column(String, nullable=True)
     currency = Column(String, nullable=False)
-    current_balance = Column(Numeric, nullable=False)
-    available_balance = Column(Numeric, nullable=True)
-    credit_limit = Column(Numeric, nullable=True)
-    overdrawn = Column(Boolean, nullable=False)
+    current_balance = column_property(
+        select(func.coalesce(func.sum(TransactionORM.amount), 0))
+        .where(
+            TransactionORM.account_id == id,
+            TransactionORM.status.in_(["active", "hidden_active"]),
+        )
+        .correlate_except(TransactionORM)
+        .scalar_subquery()
+    )
+    available_balance = column_property(
+        select(func.coalesce(func.sum(TransactionORM.amount), 0))
+        .where(
+            TransactionORM.account_id == id,
+            TransactionORM.status.in_( ["active", "hidden_active"] ),
+            TransactionORM.pending == False
+        )
+        .correlate_except(TransactionORM)
+        .scalar_subquery()
+    )
+    credit_limit = Column(BigInteger, nullable=True)
+    overdrawn = column_property(
+        and_(
+            func.lower(type).in_([
+                AccountType.CHECKING.value,
+                AccountType.CREDITCARD.value,
+                AccountType.LOAN.value
+            ]),
+            or_(
+                and_(
+                    credit_limit.is_not(None),
+                    balance_expr(id) < -credit_limit
+                ),
+                and_(
+                    credit_limit.is_(None),
+                    balance_expr(id) < 0
+                )
+            )
+        )
+    )
     status = Column(String, nullable=False)
     created = Column(DateTime, nullable=False)
     attributes = relationship("AccountAttributeORM", uselist=True)
+    provider_name = Column(String, nullable=False)
+    provider_logo = Column(String, nullable=False)
     user_id = Column(UUID(as_uuid=True), ForeignKey('users.id'), nullable=False)
 
     user = relationship(

--- a/FlaskApp/infra/db/orm/akahu_account_orm.py
+++ b/FlaskApp/infra/db/orm/akahu_account_orm.py
@@ -1,4 +1,4 @@
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, String, UUID
+from sqlalchemy import JSON, BigInteger, Boolean, Column, DateTime, ForeignKey, String, UUID
 from sqlalchemy.orm import relationship
 
 from FlaskApp.infra.db.base import Base
@@ -7,17 +7,39 @@ from FlaskApp.infra.db.base import Base
 class AkahuAccountORM(Base):
     __tablename__ = 'akahu_accounts'
 
+    # Akahu specific fields
     id = Column(String, primary_key=True)
     authorisation = Column(String, nullable=False)
     meta = Column(JSON, nullable=False)
     connection_id = Column(String, nullable=False)
-    connection_name = Column(String, nullable=False)
-    connection_logo = Column(String, nullable=False)
     connection_type = Column(String, nullable=False)
     refreshed = Column(JSON, nullable=False)
     refresh_attempt = Column(DateTime, nullable=False)
+
+    # Data used by our app - Will be used to create inital AccountORM and then kept up to date for reconciliation
+    name = Column(String, nullable=False)
+    type = Column(String, nullable=False)
+    formatted_account = Column(String, nullable=True)
+    currency = Column(String, nullable=False)
+    credit_limit = Column(BigInteger, nullable=True)
+    overdrawn = Column(Boolean, nullable=False)
+    status = Column(String, nullable=False)
+    created = Column(DateTime, nullable=False)
+    attributes = relationship("AkahuAccountAttributeORM", uselist=True)
+    current_balance = Column(BigInteger, nullable=False)
+    available_balance = Column(BigInteger, nullable=True)
+    connection_name = Column(String, nullable=False)
+    connection_logo = Column(String, nullable=False)
+
+    # Relationships
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     account_id = Column(UUID(as_uuid=True), ForeignKey("accounts.id"), nullable=False)
 
     user = relationship("UserORM")
     account = relationship("AccountORM")
+
+class AkahuAccountAttributeORM(Base):
+    __tablename__ = 'akahu_account_attributes'
+
+    account_id = Column(String, ForeignKey('akahu_accounts.id'), primary_key=True)
+    attribute = Column(String, primary_key=True)

--- a/FlaskApp/infra/db/orm/akahu_transaction_orm.py
+++ b/FlaskApp/infra/db/orm/akahu_transaction_orm.py
@@ -1,4 +1,4 @@
-from sqlalchemy import JSON, UUID, Column, DateTime, ForeignKey, String
+from sqlalchemy import JSON, UUID, Boolean, Column, DateTime, ForeignKey, BigInteger, String
 from sqlalchemy.orm import relationship
 
 from FlaskApp.infra.db.base import Base
@@ -11,6 +11,15 @@ class AkahuTransactionORM(Base):
     created = Column(DateTime, nullable=False)
     updated = Column(DateTime, nullable=False)
     meta = Column(JSON, nullable=True)
+
+    # Standard transaction fields
+    amount = Column(BigInteger, nullable=False)
+    date = Column(DateTime, nullable=False)
+    description = Column(String, nullable=False)
+    balance = Column(BigInteger, nullable=True)
+    type = Column(String, nullable=True)
+    pending = Column(Boolean, nullable=False)
+
     user_id = Column(UUID(as_uuid=True), ForeignKey('users.id'), nullable=False)
     transaction_id = Column(UUID(as_uuid=True), ForeignKey('transactions.id'), nullable=False, unique=True)
     akahu_account_id = Column(String, ForeignKey('akahu_accounts.id'), nullable=False)

--- a/FlaskApp/infra/db/orm/transaction_orm.py
+++ b/FlaskApp/infra/db/orm/transaction_orm.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import UUID, Column, DateTime, ForeignKey, Numeric, String, Boolean, Float
+from sqlalchemy import UUID, BigInteger, Column, DateTime, ForeignKey, Integer, Numeric, String, Boolean, Float
 from sqlalchemy.orm import relationship
 
 from FlaskApp.infra.db.base import Base
@@ -10,11 +10,11 @@ class TransactionORM(Base):
     __tablename__ = "transactions"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    amount = Column(Numeric, nullable=False)
+    amount = Column(BigInteger, nullable=False)
     date = Column(DateTime, nullable=False)
     description = Column(String, nullable=False)
-    balance = Column(Numeric, nullable=True)  # Not available via different import methods
-    type = Column(String, nullable=True)  # Not available via different import methods
+    balance = Column(BigInteger, nullable=True)  # Not available via different import methods
+    type = Column(String, nullable=False)
     status = Column(String, nullable=False, default='active')  # active, deleted
     pending = Column(Boolean, nullable=False)
     created = Column(DateTime, nullable=False)

--- a/FlaskApp/infra/models.py
+++ b/FlaskApp/infra/models.py
@@ -39,9 +39,9 @@ def parse_bool(val):
     if val is None:
         return None
     val = str(val).strip().lower()
-    if val in ('true', '1', 'yes', 'y', 'on'):
+    if val in ('true'):
         return True
-    if val in ('false', '0', 'no', 'n', 'off'):
+    if val in ('false'):
         return False
     raise ValueError(f"Invalid boolean value: {val}")
 

--- a/FlaskApp/infra/presentation.py
+++ b/FlaskApp/infra/presentation.py
@@ -1,0 +1,8 @@
+from decimal import Decimal
+
+
+def format_cents(cents: Decimal) -> str:
+    dollars = cents / 100
+    if dollars == 0:
+        return "0.00"
+    return f"{dollars:.2f}"

--- a/FlaskApp/infra/repositories/account.py
+++ b/FlaskApp/infra/repositories/account.py
@@ -27,6 +27,10 @@ class AccountRepository:
             return None
         return account_orm_to_domain(orm, user=user)
 
+    def get_all_for_user(self, user: User) -> list[Account]:
+        orms = self._session.query(AccountORM).filter_by(user_id=user.id).all()
+        return [account_orm_to_domain(orm, user=user) for orm in orms]
+
     def exists(self, account_id: str | UUID, user: User) -> bool:
         if isinstance(account_id, str):
             account_id = UUID(account_id)
@@ -39,10 +43,7 @@ class AccountRepository:
             existing.name = account.name
             existing.type = account.type
             existing.currency = account.currency
-            existing.current_balance = account.current_balance
-            existing.available_balance = account.available_balance
             existing.credit_limit = account.credit_limit
-            existing.overdrawn = account.overdrawn
             existing.status = account.status
             # Sync attributes
             existing_attrs = {a.attribute: a for a in
@@ -65,3 +66,11 @@ class AccountRepository:
             for attribute in [AccountAttributeORM(account_id=account.id, attribute=attr) for attr in
                               account.attributes]:
                 self._session.add(attribute)
+
+    def delete(self, user: User, account_id: str | UUID):
+        if isinstance(account_id, str):
+            account_id = UUID(account_id)
+        orm = self._session.query(AccountORM).filter_by(id=account_id, user_id=user.id).first()
+        if not orm:
+            raise Exception("Account not found")
+        orm.status = 'deleted'

--- a/FlaskApp/infra/repositories/akahu_account.py
+++ b/FlaskApp/infra/repositories/akahu_account.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from FlaskApp.domainmodel import AkahuAccount, Account, User
 from FlaskApp.infra.db.mappers import akahu_account_orm_to_domain, account_orm_to_domain, akahu_account_domain_to_orm, \
     user_orm_to_domain
-from FlaskApp.infra.db.orm import AkahuAccountORM
+from FlaskApp.infra.db.orm import AkahuAccountORM, AkahuAccountAttributeORM
 
 
 class AkahuAccountRepository:
@@ -36,14 +36,36 @@ class AkahuAccountRepository:
     def add_or_update(self, akahu_account: AkahuAccount, user: User):
         existing = self._session.query(AkahuAccountORM).filter_by(id=akahu_account.id, user_id=user.id).first()
         if existing:
-            # Update existing fields
             existing.authorisation = akahu_account.authorisation
             existing.meta = akahu_account.meta
             existing.connection_id = akahu_account.connection_id
-            existing.connection_name = akahu_account.connection_name
-            existing.connection_logo = akahu_account.connection_logo
             existing.connection_type = akahu_account.connection_type
             existing.refreshed = akahu_account.refreshed
+            existing.name = akahu_account.name
+            existing.type = akahu_account.type
+            existing.formatted_account = akahu_account.formatted_account
+            existing.currency = akahu_account.currency
+            existing.current_balance = akahu_account.current_balance
+            existing.available_balance = akahu_account.available_balance
+            existing.status = akahu_account.status
+            existing.credit_limit = akahu_account.credit_limit
+            existing.overdrawn = akahu_account.overdrawn
+            existing.connection_name = akahu_account.connection_name
+            existing.connection_logo = akahu_account.connection_logo
+
+            existing_attrs = {a.attribute: a for a in
+                              self._session.query(AkahuAccountAttributeORM).filter_by(account_id=akahu_account.id).all()}
+
+            # Delete removed attributes
+            for attr_name, attr_obj in existing_attrs.items():
+                if attr_name not in akahu_account.attributes:
+                    self._session.delete(attr_obj)
+
+            # Add new attributes
+            for attr_name in akahu_account.attributes:
+                if attr_name not in existing_attrs:
+                    new_attr = AkahuAccountAttributeORM(account_id=akahu_account.id, attribute=attr_name)
+                    self._session.add(new_attr)
         else:
             orm = akahu_account_domain_to_orm(akahu_account)
             self._session.add(orm)
@@ -52,3 +74,8 @@ class AkahuAccountRepository:
         existing = self._session.query(AkahuAccountORM).filter_by(id=akahu_account_id, user_id=user.id).first()
         if existing:
             existing.refresh_attempt = datetime.now(tz=timezone.utc)
+
+    def list_akahu_accounts(self, user: User) -> list[AkahuAccount]:
+        orms = self._session.query(AkahuAccountORM).filter_by(user_id=user.id).all()
+        user = user_orm_to_domain(orms[0].user) if orms else user
+        return [akahu_account_orm_to_domain(orm, user=user) for orm in orms]

--- a/FlaskApp/infra/repositories/akahu_transaction.py
+++ b/FlaskApp/infra/repositories/akahu_transaction.py
@@ -4,6 +4,7 @@ from FlaskApp.domainmodel import AkahuTransaction, Transaction, User
 from FlaskApp.infra.db.mappers import akahu_transaction_orm_to_domain, akahu_transaction_domain_to_orm, \
     transaction_orm_to_domain, user_orm_to_domain
 from FlaskApp.infra.db.orm import AkahuTransactionORM
+from FlaskApp.infra.db.orm.transaction_orm import TransactionORM
 
 
 class AkahuTransactionRepository:
@@ -39,3 +40,31 @@ class AkahuTransactionRepository:
         else:
             orm = akahu_transaction_domain_to_orm(akahu_transaction)
             self.session.add(orm)
+    def list_pending_transactions(self, user: User) -> list[AkahuTransaction]:
+        orms = self.session.query(AkahuTransactionORM).filter_by(pending=True, user_id=user.id).all()
+        user = user_orm_to_domain(orms[0].user) if orms else None
+        return [akahu_transaction_orm_to_domain(orm, user=user) for orm in orms]
+
+    def delete_all_pending_transactions(self, user: User):
+        # Find AkahuTransactionORMs with pending=True and related TransactionORM with pending=True
+        from sqlalchemy import and_, select
+
+        # Get transaction IDs to delete
+        subquery = (
+            self.session.query(AkahuTransactionORM.transaction_id)
+            .join(TransactionORM, AkahuTransactionORM.transaction_id == TransactionORM.id)
+            .filter(
+                AkahuTransactionORM.pending == True,
+                AkahuTransactionORM.user_id == user.id,
+                TransactionORM.pending == True
+            )
+            .subquery()
+        )
+        # Delete from TransactionORM
+        self.session.query(TransactionORM).filter(TransactionORM.id.in_(select(subquery))).delete(synchronize_session=False)
+        # Delete from AkahuTransactionORM
+        self.session.query(AkahuTransactionORM).filter(
+            AkahuTransactionORM.pending == True,
+            AkahuTransactionORM.user_id == user.id,
+            AkahuTransactionORM.transaction_id.in_(select(subquery))
+        ).delete(synchronize_session=False)

--- a/FlaskApp/infra/services.py
+++ b/FlaskApp/infra/services.py
@@ -1,10 +1,11 @@
+from decimal import ROUND_HALF_UP, Decimal
 from functools import wraps
 from http import HTTPStatus
 
 from flask import g
 from flask_restx import Namespace
 
-from FlaskApp.infra.exceptions import Unauthorized
+from FlaskApp.infra.exceptions import Unauthorized, ValidationError
 from FlaskApp.infra.models import register_global_models_to_namespace
 
 app_ns = Namespace('__App__', description='Internal namespace for application-wide models and services')
@@ -36,3 +37,18 @@ def require_auth(fn=None, ns=None):
     if fn is not None:
         return decorator(fn)
     return decorator
+
+def to_amount_cents(amount: float | str | int) -> int:
+    return int(
+    Decimal(str(amount))
+    .quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    * 100
+)
+
+def validate_uuid(value: str, field_name: str) -> str:
+    import uuid
+    try:
+        val = uuid.UUID(value, version=4)
+        return str(val)
+    except (ValueError, AttributeError, TypeError):
+        raise ValidationError(f"{field_name} must be a valid UUID4 string")

--- a/FlaskApp/routes/accounts/__init__.py
+++ b/FlaskApp/routes/accounts/__init__.py
@@ -1,0 +1,1 @@
+from FlaskApp.routes.accounts.accounts import ns

--- a/FlaskApp/routes/accounts/accounts.py
+++ b/FlaskApp/routes/accounts/accounts.py
@@ -1,0 +1,214 @@
+import enum
+from http import HTTPStatus
+
+from flask import request, g
+from flask_restx import Resource, Namespace, fields
+from iso4217 import Currency
+from werkzeug.datastructures import FileStorage
+
+from FlaskApp.domainmodel.upload import SupportedBank
+from FlaskApp.infra.db import SessionLocal
+from FlaskApp.infra.exceptions import ValidationError
+from FlaskApp.infra.models import NullableString
+from FlaskApp.domainmodel.account import AccountType, AccountAttribute
+from FlaskApp.infra.services import CREATED_RESPONSE, OK_RESPONSE, make_ok_response, require_auth, models, validate_uuid
+from FlaskApp.infra.unit_of_work import SqlAlchemyUnitOfWork
+from FlaskApp.routes.accounts.services import create_account, delete_upload, get_accounts, get_uploads, update_account, delete_account, upload_csv
+from FlaskApp.routes.accounts.presentation import account_domain_to_json, upload_domain_to_json
+
+ns = Namespace('accounts', description='Operations related to accounts')
+
+
+# region Account Models
+account_item_model = ns.model('Account', {
+    'id': fields.String(required=True, description='The account unique identifier', example='a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4'),
+    'name': fields.String(required=True, description='The name of the account', example='Everyday Checking'),
+    'type': fields.String(required=True, description='The type of the account', example='checking', enum=[e.value for e in AccountType]),
+    'formatted_account': fields.String(required=True, description='The formatted account number', example='12-3456-7890123-00'),
+    'attributes': fields.List(fields.String, required=True, description='List of account attributes', example=[e.value for e in AccountAttribute], enum=[e.value for e in AccountAttribute]),
+    'currency': fields.String(required=True, description='The currency of the account', example='NZD'),
+    'current_balance': NullableString(required=True, description='The current balance of the account', example='1000.00'),
+    'available_balance': NullableString(required=True, description='The available balance of the account', example='800.00'),
+    'status': fields.String(required=True, description='The status of the account', example='active'),
+    'created': fields.DateTime(required=True, description='The date and time when the account was created', example='2024-01-01T12:00:00Z'),
+    'credit_limit': NullableString(description='The credit limit of the account (if applicable)', example='5000.00'),
+    'overdrawn': fields.Boolean(required=True, description='Whether the account is overdrawn or not', example=False),
+    'provider_name': fields.String(required=True, description='The name of the account provider', example='Bank of Example'),
+    'provider_logo': fields.String(required=True, description='The logo of the account provider', example='https://example.com/logo.png'),
+})
+
+accounts_model = ns.model('AccountListResponse', {
+    'success': fields.Boolean(required=True, description='Indicates if the request was successful'),
+    'accounts': fields.List(fields.Nested(account_item_model), description='List of accounts')
+})
+
+
+editable_account_model = ns.model('AccountUpdate', {
+    'name': fields.String(required=True, description='The name of the account', example='Everyday Checking'),
+    'type': fields.String(required=True, description='The type of the account', example='checking', enum=[e.value for e in AccountType]),
+    'formatted_account': fields.String(required=True, description='The formatted account number', example='12-3456-7890123-00'),
+    'attributes': fields.List(fields.String, required=True, description='List of account attributes', example=[e.value for e in AccountAttribute], enum=[e.value for e in AccountAttribute]),
+    'currency': fields.String(required=True, description='The currency of the account. ISO 4217 currency code', example='NZD'), # Iso 4217 currency code
+    'credit_limit': NullableString(required=True, description='The credit limit of the account (if applicable)', example="5000.00"),
+})
+
+# endregion
+
+# region Upload Models and Parsers
+
+upload_transaction_model = ns.model('UploadTransactionResponse', {
+    "success": fields.Boolean(description='Indicates if the request was successful', example=True),
+    "uploads": fields.List(fields.Nested(ns.model('UploadItem', {
+        'id': fields.String(readOnly=True, description='The unique identifier of an upload',
+                            example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
+        'filename': fields.String(description='Original filename of the uploaded CSV file', example="transactions.csv"),
+        'bank': fields.String(description='Bank associated with the uploaded transactions', example="ANZ"),
+        'created': fields.DateTime(description='Timestamp when the file was uploaded', example="2024-01-01T12:00:00Z"),
+        'transaction_count': fields.Integer(description='Number of transactions associated with the upload',
+                                            example=100),
+    })))
+})
+
+# Parser
+upload_csv_parser = ns.parser()
+upload_csv_parser.add_argument('file', location='files', type=FileStorage, required=True)
+upload_csv_parser.add_argument('bank', location='form', type=str, choices=[bank.value for bank in SupportedBank],
+                               help=f'Bank associated with the uploaded transactions.', required=True)
+
+# endregion
+
+
+@ns.route('')
+class Account(Resource):
+    @ns.response(HTTPStatus.OK, 'Success', accounts_model)
+    @require_auth(ns=ns)
+    def get(self):
+        """Get all accounts for the authenticated user"""
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        accounts = get_accounts(uow=uow, user=g.current_user)
+        accounts_json = [account_domain_to_json(a) for a in accounts]
+        return make_ok_response(accounts=accounts_json)
+
+    @ns.expect(editable_account_model, validate=True)
+    @ns.response(HTTPStatus.CREATED, 'Success', models['OK'])
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @require_auth(ns=ns)
+    def post(self):
+        """Create a new account for the authenticated user"""
+        data = request.get_json()
+
+        # Validation
+        if data['currency'] not in Currency:
+            raise ValidationError(f"Invalid currency code: {data['currency']}. Must be a valid ISO 4217 currency code.")
+        if data['attributes']:
+            for attr in data['attributes']:
+                if attr not in AccountAttribute._value2member_map_:
+                    raise ValidationError(f"Invalid account attribute: {attr}. Must be one of {[e.value for e in AccountAttribute]}")
+        if data['type'] not in AccountType._value2member_map_:
+            raise ValidationError(f"Invalid account type: {data['type']}. Must be one of {[e.value for e in AccountType]}")
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        create_account(uow, user=g.current_user, **data)
+        return CREATED_RESPONSE
+
+
+
+@ns.route('/<string:account_id>')
+class AccountById(Resource):
+    @ns.expect(editable_account_model, validate=True)
+    @ns.response(HTTPStatus.OK, 'Success', models['OK'])
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @require_auth(ns=ns)
+    def put(self, account_id):
+        """Update an existing account for the authenticated user"""
+        data = request.get_json()
+
+        # Validation
+        validate_uuid(account_id, field_name='id')
+        if data['currency'] not in Currency:
+            raise ValidationError(f"Invalid currency code: {data['currency']}. Must be a valid ISO 4217 currency code.")
+        if data['attributes']:
+            for attr in data['attributes']:
+                if attr not in AccountAttribute._value2member_map_:
+                    raise ValidationError(f"Invalid account attribute: {attr}. Must be one of {[e.value for e in AccountAttribute]}")
+        if data['type'] not in AccountType._value2member_map_:
+            raise ValidationError(f"Invalid account type: {data['type']}. Must be one of {[e.value for e in AccountType]}")
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        update_account(uow, user=g.current_user, account_id=account_id, **data)
+        return OK_RESPONSE
+
+    @ns.expect(editable_account_model, validate=True)
+    @ns.response(HTTPStatus.OK, 'Success', models['OK'])
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @require_auth(ns=ns)
+    def delete(self, account_id):
+        """Delete an existing account"""
+        validate_uuid(account_id, field_name='id')
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        delete_account(uow, user=g.current_user, account_id=account_id)
+        return OK_RESPONSE
+
+@ns.route('/<string:account_id>/upload')
+class CSVUpload(Resource):
+
+    @ns.response(HTTPStatus.OK, 'OK', upload_transaction_model)
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.param('account_id', description='The unique identifier of the account', example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
+    @ns.doc(
+        description="Get a list of uploaded CSV files. This will include metadata about the upload but not the transactions themselves.")
+    @require_auth(ns=ns)
+    def get(self, account_id):
+        """Get a list of uploaded CSV files."""
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        uploads = get_uploads(uow=uow, user=g.current_user)
+        uploads_json = [upload_domain_to_json(upload) for upload in uploads]
+        return {"success": True, "uploads": uploads_json}, HTTPStatus.OK
+
+    @ns.response(HTTPStatus.CREATED, 'OK', models['OK'])
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.expect(upload_csv_parser, validate=True)
+    @ns.param('account_id', description='The unique identifier of the account', example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
+    @ns.doc(
+        description="Upload a CSV file of transactions. Supported banks: ANZ, Kiwibank. CSV format must match the format provided by the bank's online transaction export.")
+    @require_auth(ns=ns)
+    def post(self, account_id):
+        """Upload a CSV file of transactions."""
+
+        # Validation
+        args = upload_csv_parser.parse_args()
+        file = args.get('file')
+        bank = args.get('bank')
+        validate_uuid(account_id, "account_id")
+        if not file:
+            raise ValidationError("No file provided")
+        filename = file.filename.lower()
+        if not (filename.endswith('.csv')):
+            raise ValidationError("Unsupported file format. Only CSV files are supported.")
+        if not bank.lower() in [bank.value for bank in SupportedBank]:
+            raise ValidationError(f"Unsupported bank. Supported banks: {[bank.value for bank in SupportedBank]}")
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        upload_csv(uow=uow, file=file, user=g.current_user, bank=bank, account_id=account_id)
+        return CREATED_RESPONSE
+
+
+@ns.route('/<string:account_id>/upload/<string:upload_id>')
+class UploadByID(Resource):
+
+    @ns.response(HTTPStatus.OK, 'OK', models['OK'])
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.param('upload_id', description='The unique identifier of the upload', example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
+    @ns.param('account_id', description='The unique identifier of the account', example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
+    @ns.doc(
+        description="Delete an uploaded CSV file of transactions. This will delete any transactions that were created from the upload.")
+    @require_auth(ns=ns)
+    def delete(self, _, upload_id):
+        """Delete an uploaded CSV file of transactions."""
+
+        # Validation
+        validate_uuid(upload_id, "upload_id")
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        delete_upload(uow=uow, user=g.current_user, upload_id=upload_id)
+        return OK_RESPONSE

--- a/FlaskApp/routes/accounts/assemblers.py
+++ b/FlaskApp/routes/accounts/assemblers.py
@@ -1,4 +1,8 @@
+from decimal import Decimal
 import pandas as pd
+
+from FlaskApp.domainmodel.transaction import TransactionType
+from FlaskApp.infra.services import to_amount_cents
 
 
 def upload_csv_anz(df: pd.DataFrame) -> pd.DataFrame:
@@ -41,20 +45,50 @@ def upload_csv_anz(df: pd.DataFrame) -> pd.DataFrame:
                     out += val
             return out
 
-        if any(keyword.lower() in type_val for keyword in ['Visa', 'Transfer']):
+        if any(keyword.lower() in type_val for keyword in ['visa', 'transfer']):
             parts = [row.get('code'), row.get('particulars'), row.get('reference'), '\n', row.get('details')]
         else:
             parts = [row.get('details'), row.get('code'), row.get('particulars'), row.get('reference')]
         desc = join_with_space(parts)
         return desc.strip() if desc else None
 
-    # Format columns
+    def convert_type(row: pd.Series) -> str | None:
+        type = row.get('type').lower()
+
+        match type:
+            case 'visa purchase': return TransactionType.CREDIT_CARD.value
+            # case 'visa refund': return TransactionType.CREDIT.value
+            case 'transfer': return TransactionType.TRANSFER.value
+            case 'payment': return TransactionType.PAYMENT.value if row.get('amount', 0) < 0 else TransactionType.CREDIT.value
+            case 'salary': return TransactionType.CREDIT.value
+            case 'eftpos': return TransactionType.EFTPOS.value
+            case 'direct credit': return TransactionType.DIRECT_CREDIT.value
+            case 'direct debit': return TransactionType.DIRECT_DEBIT.value
+            case 'bill payment': return TransactionType.PAYMENT.value
+            case _ if 'atm' in type: return TransactionType.ATM.value
+            case _ if 'tax' in type: return TransactionType.TAX.value
+            case _ if 'interest' in type: return TransactionType.INTEREST.value
+            case _ if 'fee' in type: return TransactionType.FEE.value
+            case _ if 'loan' in type: return TransactionType.LOAN.value
+            case _ if 'auto' in type: return TransactionType.STANDING_ORDER.value
+
+            case _ if row.get('amount', 0) <= 0: return TransactionType.DEBIT.value
+            case _ if row.get('amount', 0) > 0: return TransactionType.CREDIT.value
+            case _: return TransactionType.PAYMENT.value
+
+
     # Description: For Visa and Transfer transactions, use code as the primary description. For all other transactions, use details as the primary description. In both cases, merge particulars, code, and reference into the description if they are not empty.
     df["description"] = df.apply(merge_description, axis=1)
     df = df.drop(columns=['code', 'particulars', 'reference', 'details'])
 
     # Date: Convert from DD/MM/YYYY to datetime
     df['date'] = pd.to_datetime(df['date'], format='%d/%m/%Y', errors='coerce').dt.strftime('%Y-%m-%d')
+
+    # Amount: Convert from dollars to cents
+    df['amount'] = df['amount'].apply(lambda x: to_amount_cents(x) if pd.notnull(x) else None)
+
+    # Type: Convert to our types
+    df['type'] = df.apply(convert_type, axis=1)
 
     return df
 
@@ -99,7 +133,23 @@ def upload_csv_kiwibank(df: pd.DataFrame) -> pd.DataFrame:
             desc_lines.append(f"OP: ({', '.join(op_valid)})")
         return '\n'.join(desc_lines) if desc_lines else None
 
-    # Format columns
+    def convert_type(row: pd.Series) -> str | None:
+        type = row.get('type').lower()
+
+        match type:
+
+            case 'dd': return TransactionType.DIRECT_CREDIT.value
+            case 'dc': return TransactionType.DIRECT_DEBIT.value
+            case _ if row['memo_description'][:2].lower() == 'ap': return TransactionType.STANDING_ORDER.value
+            case _ if row['memo_description'][:3].lower() == 'pos': return TransactionType.EFTPOS.value
+
+            case _ if row.get('amount', 0) <= 0: return TransactionType.PAYMENT.value
+            case _ if row.get('amount', 0) > 0: return TransactionType.CREDIT.value
+            case _: return TransactionType.PAYMENT.value
+
+    # Type: Map Kiwibank source codes to our transaction types.
+    df['type'] = df.apply(convert_type, axis=1)
+
     # Description: Merge memo_description, TP details, and OP details into a single description field. Only include non-empty values.
     df['description'] = df.apply(merge_description, axis=1)
     df = df.drop(
@@ -107,5 +157,11 @@ def upload_csv_kiwibank(df: pd.DataFrame) -> pd.DataFrame:
 
     # Date: Convert from DD/MM/YYYY to datetime
     df['date'] = pd.to_datetime(df['date'], format='%d-%m-%Y', errors='coerce').dt.strftime('%Y-%m-%d')
+
+    # Amount: Convert from dollars to cents
+    df['amount'] = df['amount'].apply(lambda x: to_amount_cents(x) if pd.notnull(x) else None)
+
+    # Balance: Convert from dollars to cents
+    df['balance'] = df['balance'].apply(lambda x: to_amount_cents(x) if pd.notnull(x) else None)
 
     return df

--- a/FlaskApp/routes/accounts/presentation.py
+++ b/FlaskApp/routes/accounts/presentation.py
@@ -1,0 +1,33 @@
+
+
+from FlaskApp.domainmodel import Account
+from FlaskApp.domainmodel.upload import Upload
+from FlaskApp.infra.presentation import format_cents
+
+
+def account_domain_to_json(account: Account):
+    return {
+        'id': str(account.id),
+        'name': account.name,
+        'type': account.type,
+        'formatted_account': account.formatted_account,
+        'attributes': account.attributes,
+        'currency': account.currency,
+        'current_balance': format_cents(account.current_balance),
+        'available_balance': format_cents(account.available_balance) if account.available_balance is not None else None,
+        'status': account.status,
+        'created': account.created.isoformat(),
+        'credit_limit': format_cents(account.credit_limit) if account.credit_limit is not None else None,
+        'overdrawn': account.overdrawn,
+        'provider_name': account.provider_name,
+        'provider_logo': account.provider_logo,
+    }
+
+def upload_domain_to_json(upload: Upload) -> dict:
+    return {
+        "id": str(upload.id),
+        "filename": upload.file_name,
+        "bank": upload.bank,
+        "created": upload.created.isoformat(),
+        "transaction_count": len(upload.transaction_ids)
+    }

--- a/FlaskApp/routes/accounts/services.py
+++ b/FlaskApp/routes/accounts/services.py
@@ -1,0 +1,130 @@
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pandas as pd
+from werkzeug.datastructures import FileStorage
+
+from FlaskApp.domainmodel import Account, User, Upload, Transaction
+from FlaskApp.infra.exceptions import AppError
+from FlaskApp.infra.services import to_amount_cents
+from FlaskApp.infra.unit_of_work import AbstractUnitOfWork
+from FlaskApp.routes.accounts.assemblers import upload_csv_anz, upload_csv_kiwibank
+
+def create_account(uow: AbstractUnitOfWork, user: User, name: str, type: str, formatted_account: str, attributes: list, currency: str, credit_limit: str):
+    with uow:
+        account = Account(
+            account_id=uuid.uuid4(),
+            account_name=name,
+            account_type=type,
+            formatted_account=formatted_account,
+            attributes=attributes,
+            currency=currency,
+            current_balance=0,  # We set this to 0 as it will be updated when transactions are added. (Only domain state, not persisted value)
+            available_balance=0,  # We set this to 0 as it will be updated when transactions are added. (Only domain state, not persisted value)
+            status='active',
+            created=datetime.now(timezone.utc),
+            credit_limit=to_amount_cents(credit_limit),
+            provider_name='Spendly',  # We set this to Spendly as it's a user-created account. (Only domain state, not persisted value)
+            provider_logo='about:blank', # TODO: Our logo
+            overdrawn=False,  # We set this to False as it will be updated when transactions are added. (Only domain state, not persisted value)
+            user=user
+        )
+        uow.accounts.add(account)
+
+def get_accounts(uow: AbstractUnitOfWork, user: User):
+    with uow:
+        accounts = uow.accounts.get_all_for_user(user=user)
+        return accounts
+
+def update_account(uow: AbstractUnitOfWork, user: User, account_id: str, name: str, type: str, formatted_account: str, attributes: list, currency: str, credit_limit: str):
+    with uow:
+        account = uow.accounts.get(account_id=account_id, user=user)
+        if not account:
+            raise AppError("Account not found")
+        account.name = name
+        account.type = type
+        account.formatted_account = formatted_account
+        account.attributes = attributes
+        account.currency = currency
+        account.credit_limit = to_amount_cents(credit_limit)
+        uow.accounts.add_or_update(account, user=user)
+
+def delete_account(uow: AbstractUnitOfWork, user: User, account_id: str):
+    with uow:
+        account = uow.accounts.get(account_id=account_id, user=user)
+        if not account:
+            raise AppError("Account not found")
+        uow.accounts.delete(account_id, user=user)
+
+def get_uploads(uow: AbstractUnitOfWork, user: User):
+    with uow:
+        uploads = uow.uploads.list_uploads(user=user)
+        return uploads
+
+
+def upload_csv(uow: AbstractUnitOfWork, user: User, file: FileStorage, bank: str, account_id: str):
+    df = pd.read_csv(file)
+
+    bank_parsers = {
+        "anz": upload_csv_anz,
+        "kiwibank": upload_csv_kiwibank,
+    }
+    parser = bank_parsers.get(bank)
+
+    try:
+        df = parser(df)
+    except KeyError:
+        raise AppError(f"Unexpected CSV format. Suggested fix: Check selected bank ({bank})")
+
+    with uow:
+        account = uow.accounts.get(account_id, user=user)
+        if account is None:
+            raise Exception("Account not found")
+
+        upload = Upload(
+            upload_id=uuid.uuid4(),
+            file_name=file.filename,
+            user=user,
+            transaction_ids=[],
+            status='pending',
+            bank=bank,
+            created=datetime.now(tz=timezone.utc)
+        )
+
+        for _, row in df.iterrows():
+            # TODO: Add category and merchant matching logic
+            transaction_id = uuid.uuid4()
+            upload.add_transaction(transaction_id)
+
+            transaction = Transaction(
+                transaction_id=transaction_id,
+                amount=row['amount'], # Amount is already converted to cents in assembler
+                date=datetime.fromisoformat(row['date']),
+                description=row['description'],
+                transaction_type=row['type'],
+                status='active',
+                balance=row['balance'] if 'balance' in row else None,
+                pending=False,
+                # Currently, no supported banks have pending transactions in their CSV exports, so default to False. Can add support later if needed.
+                created=datetime.now(tz=timezone.utc),
+                latitude=None,
+                longitude=None,
+                category=None,
+                account=account,
+                merchant=None,
+                user=user,
+            )
+
+            uow.transactions.add(transaction)
+
+        uow.uploads.add(upload)
+
+
+def delete_upload(uow: AbstractUnitOfWork, user: User, upload_id: str):
+    with uow:
+        exists = uow.uploads.exists(upload_id, user=user)
+        if not exists:
+            raise Exception("Upload not found")
+        uow.uploads.delete(upload_id, user=user)
+

--- a/FlaskApp/routes/akahu/akahu.py
+++ b/FlaskApp/routes/akahu/akahu.py
@@ -4,11 +4,13 @@ from flask import request, g
 from flask_restx import Resource, Namespace, fields
 
 from FlaskApp.infra.db import SessionLocal
-from FlaskApp.infra.services import OK_RESPONSE, models
+from FlaskApp.infra.exceptions import ValidationError
+from FlaskApp.infra.services import OK_RESPONSE, make_ok_response, models
 from FlaskApp.infra.services import require_auth
 from FlaskApp.infra.unit_of_work import SqlAlchemyUnitOfWork
-from FlaskApp.routes.akahu.services import sync_akahu, connect_akahu
-
+from FlaskApp.routes.akahu.presentation import akahu_account_domain_to_json, compare_akahu_account_domain_to_json
+from FlaskApp.routes.akahu.services import sync_akahu, connect_akahu, get_akahu_accounts, balance_akahu_account
+from FlaskApp.routes.accounts.accounts import account_item_model
 ns = Namespace('akahu', description='Akahu integration endpoints')
 
 # region Models
@@ -19,6 +21,46 @@ akahu_connect_model = ns.model('AkahuConnect', {
                                   example='app_token_123'),
 })
 
+akahu_balance_account_model = ns.model('AkahuAccountBalance', {
+        'akahu_account_id': fields.String(description="List of Akahu account IDs to refresh. If empty, all accounts will be refreshed.", example="acc_abcdefghijklmnopqrstuvwxy")
+    })
+
+akahu_account_item_model = ns.model('AkahuAccount', {
+    "id": fields.String(description="Akahu account ID"),
+    "authorisation": fields.String(description="Authorization status of the account"),
+    "meta": fields.Raw(description="Metadata associated with the account"),
+    "connection_id": fields.String(description="ID of the Akahu connection"),
+    "connection_type": fields.String(description="Type of the Akahu connection"),
+    "refreshed": fields.DateTime(description="Last refreshed timestamp"),
+    "refresh_attempt": fields.DateTime(description="Last refresh attempt timestamp"),
+
+    # Similar field to accounts
+    "name": fields.String(description="Name of the account", example="My Checking Account"),
+    "type": fields.String(description="Type of the account", example="CHECKING"),
+    "formatted_account": fields.String(description="Formatted account details", example="12-3456-7890123-00"),
+    "currency": fields.String(description="Currency code", example="USD"),
+    "current_balance": fields.String(description="Current balance as a string to preserve precision", example="100.50"),
+    "available_balance": fields.String(description="Available balance as a string to preserve precision", example="80.00"),
+    "status": fields.String(description="Status of the account", example="active"),
+    "created": fields.DateTime(description="Account creation timestamp", example="2023-01-01T00:00:00Z"),
+    "credit_limit": fields.String(description="Credit limit as a string to preserve precision", example="500.00"),
+    "overdrawn": fields.Boolean(description="Whether the account is overdrawn", example=False),
+    "connection_name": fields.String(description="Name of the connected institution", example="Bank A"),
+    "connection_logo": fields.String(description="URL of the institution's logo", example="https://logo.url/bank_a.png"),
+})
+
+akahu_accounts_model = ns.model('AkahuAccounts', {
+    'success': fields.Boolean(description="Whether the request was successful"),
+    'accounts': fields.List(fields.Nested(akahu_account_item_model), description="List of Akahu accounts")
+})
+
+akahu_account_comparison_model = ns.model('AkahuAccountComparison', {
+    'success': fields.Boolean(description="Whether the request was successful"),
+    'accounts': fields.List(fields.Nested(ns.model('AkahuAccountComparisonItem', {
+        'akahu_account': fields.Nested(akahu_account_item_model, description="The Akahu account details"),
+        'spendly_account': fields.Nested(account_item_model, description="The corresponding Spendly account details")
+    })), description="List of Akahu accounts with their corresponding Spendly accounts")
+})
 
 # endregion
 
@@ -29,7 +71,7 @@ class AkahuResource(Resource):
     @ns.doc(description="Sync Akahu data with Spendly")
     @ns.response(HTTPStatus.OK, 'OK', models['OK'])
     @ns.param('full_sync', 'Whether to perform a full sync. Default is false, which only syncs latest 50 transactions.',
-              "query", default="False", type="boolean")
+              "query", default=False, type="boolean")
     def get(self):
         """Download latest data from Akahu and update Spendly accounts and transactions"""
         uow = SqlAlchemyUnitOfWork(SessionLocal)
@@ -55,4 +97,41 @@ class AkahuResource(Resource):
             uow=uow,
             user=g.current_user
         )
+        return OK_RESPONSE
+
+@ns.route('/accounts')
+class AkahuAccountsResource(Resource):
+    @ns.param('compare', 'Whether to compare with existing accounts and only return new accounts. Default is false.',
+              "query", default=False, type="boolean")
+    @ns.doc(description="Get all accounts linked with Akahu for the authenticated user")
+    @ns.response(HTTPStatus.OK, 'OK', akahu_accounts_model)
+    @ns.response(f'{HTTPStatus.OK} (compared)', 'OK (compared)', akahu_account_comparison_model)
+    @require_auth(ns=ns)
+    def get(self):
+        """Get all accounts linked with Akahu for the authenticated user"""
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        request_args = request.args
+        compare = request_args.get('compare', 'false').lower() == 'true'
+
+        accounts = get_akahu_accounts(uow=uow, user=g.current_user, compare=compare)
+
+        if compare:
+            accounts_json = [compare_akahu_account_domain_to_json(ak, ac) for ak, ac in accounts.items()]
+        else:
+            accounts_json = [akahu_account_domain_to_json(ak) for ak in accounts]
+        return make_ok_response(accounts=accounts_json)
+
+    @ns.response(HTTPStatus.OK, 'OK', models['OK'])
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation error', models['BadRequest'])
+    @ns.expect(akahu_balance_account_model, validate=True)
+    @ns.doc(description="Balance Akahu account by recalculating the balance based on transactions. This is useful when transactions are added/updated outside of the normal sync process.")
+    @require_auth(ns=ns)
+    def put(self):
+        """Balance Akahu account by recalculating the balance based on transactions. This is useful when transactions are added/updated outside of the normal sync process."""
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        payload = request.get_json()
+        akahu_account_id = payload.get("akahu_account_id")
+        if not akahu_account_id:
+            raise ValidationError("akahu_account_id is required")
+        balance_akahu_account(uow=uow, akahu_account_id=akahu_account_id, user=g.current_user)
         return OK_RESPONSE

--- a/FlaskApp/routes/akahu/assemblers.py
+++ b/FlaskApp/routes/akahu/assemblers.py
@@ -1,15 +1,16 @@
+from decimal import ROUND_HALF_UP, Decimal
 import uuid
 from datetime import datetime, timezone
 
 from FlaskApp.domainmodel import Transaction, AkahuTransaction, User, AkahuAccount, AkahuCategory, AkahuMerchant, \
     Merchant, Category, Account
+from FlaskApp.infra.services import to_amount_cents
 
 
 def akahu_transaction_to_domain(
         akahu_tx,
         *,
-        existing_transaction: Transaction | None = None,
-        is_pending: bool,
+        existing_akahu_transaction: AkahuTransaction | None = None,
         user: User,
         account: Account,
         akahu_account: AkahuAccount,
@@ -18,16 +19,44 @@ def akahu_transaction_to_domain(
         merchant: Merchant | None = None,
         akahu_merchant: AkahuMerchant | None = None,
 ) -> tuple[Transaction, AkahuTransaction]:
-    # Let repository handle updating exsiting transaction. Here just create a new object
+    # Let repository handle updating exsiting transaction. Here just update all possible fields
+    if existing_akahu_transaction:
+        # Update non-overwritten fields on transaction. Observed as not overwritten if no difference is detected
+        transaction = existing_akahu_transaction.transaction
+
+        if existing_akahu_transaction.amount == transaction.amount:
+            transaction.amount=to_amount_cents(akahu_tx['amount'])
+        if existing_akahu_transaction.date == transaction.date:
+            transaction.date=datetime.fromisoformat(akahu_tx['date'])
+        if existing_akahu_transaction.description == transaction.description:
+            transaction.description=akahu_tx['description']
+        if existing_akahu_transaction.balance == transaction.balance:
+            transaction.balance=to_amount_cents(akahu_tx['balance']) if akahu_tx['balance'] is not None else None
+        if existing_akahu_transaction.type == transaction.type:
+            transaction.type=akahu_tx['type'].lower()
+
+        existing_akahu_transaction.created=datetime.fromisoformat(akahu_tx['created_at']) # Should not change but just in case
+        existing_akahu_transaction.updated=datetime.fromisoformat(akahu_tx['updated_at'])
+        existing_akahu_transaction.meta=akahu_tx['meta']
+        existing_akahu_transaction.amount=to_amount_cents(akahu_tx['amount'])
+        existing_akahu_transaction.date=datetime.fromisoformat(akahu_tx['date'])
+        existing_akahu_transaction.description=akahu_tx['description']
+        existing_akahu_transaction.balance=to_amount_cents(akahu_tx['balance']) if akahu_tx['balance'] is not None else None
+        existing_akahu_transaction.type=akahu_tx['type'].lower()
+        existing_akahu_transaction.akahu_merchant = akahu_merchant
+        existing_akahu_transaction.akahu_category = akahu_category
+
+        return transaction, existing_akahu_transaction
+
     transaction = Transaction(
-        transaction_id=existing_transaction.id if existing_transaction else uuid.uuid4(),
-        amount=akahu_tx['amount'],
+        transaction_id=uuid.uuid4(),
+        amount=to_amount_cents(akahu_tx['amount']),
         date=datetime.fromisoformat(akahu_tx['date']),
         description=akahu_tx['description'],
-        balance=akahu_tx['balance'],
-        transaction_type=akahu_tx['type'],
+        balance=to_amount_cents(akahu_tx['balance']) if akahu_tx['balance'] is not None else None,
+        transaction_type=akahu_tx['type'].lower(),
         status='active',
-        pending=is_pending,
+        pending=False,
         created=datetime.fromisoformat(akahu_tx['created_at']),
         latitude=None,
         longitude=None,
@@ -42,6 +71,14 @@ def akahu_transaction_to_domain(
         created=datetime.fromisoformat(akahu_tx['created_at']),
         updated=datetime.fromisoformat(akahu_tx['updated_at']),
         meta=akahu_tx['meta'],
+
+        amount=to_amount_cents(akahu_tx['amount']),
+        date=datetime.fromisoformat(akahu_tx['date']),
+        description=akahu_tx['description'],
+        balance=to_amount_cents(akahu_tx['balance']) if akahu_tx['balance'] is not None else None,
+        type=akahu_tx['type'],
+        pending=False,
+
         user=user,
         transaction=transaction,
         akahu_account=akahu_account,
@@ -51,28 +88,113 @@ def akahu_transaction_to_domain(
 
     return transaction, akahu_transaction
 
+def akahu_pending_transaction_to_domain(
+        akahu_tx,
+        *,
+        user: User,
+        account: Account,
+        akahu_account: AkahuAccount,
+) -> tuple[Transaction, AkahuTransaction]:
+
+    transaction = Transaction(
+        transaction_id=uuid.uuid4(),
+        amount=to_amount_cents(akahu_tx['amount']),  # Convert dollars to cents
+        date=datetime.fromisoformat(akahu_tx['date']),
+        description=akahu_tx['description'],
+        balance=None,
+        transaction_type=akahu_tx['type'].lower(),
+        status='active',
+        pending=True,
+        created=datetime.now(tz=timezone.utc),  # Our created timestamp since Akahu doesn't provide one for pending transactions
+        latitude=None,
+        longitude=None,
+        user=user,
+        account=account,
+        category=None,
+        merchant=None,
+    )
+
+    akahu_transaction = AkahuTransaction(
+        akahu_transaction_id=f"pending-{uuid.uuid4().hex}",  # Pending transactions have a temporary ID to avoid conflicts with existing transactions
+        created=datetime.now(tz=timezone.utc),  # Our created timestamp since Akahu doesn't provide one for pending transactions
+        updated=datetime.fromisoformat(akahu_tx['updated_at']),
+        meta={},
+        amount=to_amount_cents(akahu_tx['amount']),
+        date=datetime.fromisoformat(akahu_tx['date']),
+        description=akahu_tx['description'],
+        balance=None,
+        type=akahu_tx['type'],
+        pending=True,
+        user=user,
+        transaction=transaction,
+        akahu_account=akahu_account,
+        akahu_category=None,
+        akahu_merchant=None
+    )
+
+    return transaction, akahu_transaction
 
 def akahu_account_to_domain(
         akahu_account,
         *,
-        existing_account: Account | None = None,
+        existing_akahu_account: AkahuAccount | None,
         user: User,
 ) -> tuple[Account, AkahuAccount]:
-    # Let repository handle updating exsiting account. Here just create a new object
+    # Let repository handle updating exsiting account.
+    if existing_akahu_account:
+        account = existing_akahu_account.account
+
+        # Update non-overwritten fields on account. Observed as not overwritten if no difference is detected
+        if existing_akahu_account.name == account.name:
+            account.name = akahu_account['name']
+        if existing_akahu_account.type.lower() == account.type:
+            account.type = akahu_account['type'].lower()
+        if existing_akahu_account.formatted_account == account.formatted_account:
+            account.formatted_account = akahu_account['formatted_account']
+        if [x.lower() for x in existing_akahu_account.attributes] == account.attributes:
+            account.attributes = [x.lower() for x in akahu_account['attributes']]
+        if existing_akahu_account.currency == account.currency:
+            account.currency = akahu_account['balance']['currency']
+        if existing_akahu_account.credit_limit == account.credit_limit:
+            account.credit_limit = to_amount_cents(akahu_account['balance']['limit']) if 'limit' in akahu_account['balance'] else None
+
+        # Update all possible fields on existing akahu account
+        existing_akahu_account.authorisation = akahu_account['_authorisation']
+        existing_akahu_account.meta = akahu_account['meta']
+        existing_akahu_account.connection_id = akahu_account['connection']['_id']
+        existing_akahu_account.connection_type = akahu_account['connection']['connection_type']
+        existing_akahu_account.refreshed = akahu_account['refreshed']
+        existing_akahu_account.name = akahu_account['name']
+        existing_akahu_account.type = akahu_account['type'].lower()
+        existing_akahu_account.formatted_account = akahu_account['formatted_account']
+        existing_akahu_account.attributes = akahu_account['attributes']
+        existing_akahu_account.currency = akahu_account['balance']['currency']
+        existing_akahu_account.current_balance = to_amount_cents(akahu_account['balance']['current'])
+        existing_akahu_account.available_balance = to_amount_cents(akahu_account['balance']['available']) if 'available' in akahu_account['balance'] else None
+        existing_akahu_account.status = 'active' if akahu_account['status'] == 'ACTIVE' else 'deleted'
+        existing_akahu_account.credit_limit = to_amount_cents(akahu_account['balance']['limit']) if 'limit' in akahu_account['balance'] else None
+        existing_akahu_account.overdrawn = akahu_account['balance']['overdrawn'] if 'overdrawn' in akahu_account['balance'] else None
+        existing_akahu_account.connection_name = akahu_account['connection']['name']
+        existing_akahu_account.connection_logo = akahu_account['connection']['logo']
+
+        return account, existing_akahu_account
+
+    # No existing account, create new account and akahu account
     account = Account(
-        account_id=existing_account.id if existing_account else uuid.uuid4(),
+        account_id=uuid.uuid4(),
         account_name=akahu_account['name'],
-        account_type=akahu_account['type'],
+        account_type=akahu_account['type'].lower(),
         formatted_account=akahu_account['formatted_account'],
-        attributes=akahu_account['attributes'],
+        attributes=[a.lower() for a in akahu_account['attributes']],
         currency=akahu_account['balance']['currency'],
-        current_balance=akahu_account['balance']['current'],
-        available_balance=akahu_account['balance']['available'],
-        status=akahu_account['status'],
-        created=datetime.now(tz=timezone.utc),
-        # Akahu doesn't provide a created timestamp for accounts, so we use the current time
-        credit_limit=akahu_account['balance']['limit'],
-        overdrawn=akahu_account['balance']['overdrawn'],
+        current_balance=0,  # We set this to 0 as it will be updated when transactions are added. (Only domain state, not persisted value)
+        available_balance=0,  # We set this to 0 as it will be updated when transactions are added. (Only domain state, not persisted value)
+        status='active' if akahu_account['status'] == 'ACTIVE' else 'deleted',
+        created=datetime.now(tz=timezone.utc), # Akahu doesn't provide a created timestamp for accounts, so we use the current time
+        provider_name=akahu_account['connection']['name'],
+        provider_logo=akahu_account['connection']['logo'],
+        credit_limit=to_amount_cents(akahu_account['balance']['limit']) if 'limit' in akahu_account['balance'] else None,
+        overdrawn=akahu_account['balance']['overdrawn'] if 'overdrawn' in akahu_account['balance'] else None,
         user=user,
     )
 
@@ -81,11 +203,24 @@ def akahu_account_to_domain(
         authorisation=akahu_account['_authorisation'],
         meta=akahu_account['meta'],
         connection_id=akahu_account['connection']['_id'],
+        connection_type=akahu_account['connection']['connection_type'],
+        refreshed={k: datetime.fromisoformat(v) for k, v in akahu_account['refreshed'].items()},
+        refresh_attempt=datetime.now(tz=timezone.utc),  # Our refresh attempt
+
+        account_name=akahu_account['name'],
+        account_type=akahu_account['type'],
+        formatted_account=akahu_account['formatted_account'],
+        attributes=akahu_account['attributes'],
+        currency=akahu_account['balance']['currency'],
+        current_balance=to_amount_cents(akahu_account['balance']['current']),
+        available_balance=to_amount_cents(akahu_account['balance']['available']) if 'available' in akahu_account['balance'] else None,
+        status='active' if akahu_account['status'] == 'ACTIVE' else 'deleted',
+        created=datetime.now(tz=timezone.utc), # Akahu doesn't provide a created timestamp for accounts, so we use the current time
+        credit_limit=to_amount_cents(akahu_account['balance']['limit']) if 'limit' in akahu_account['balance'] else None,
+        overdrawn=akahu_account['balance']['overdrawn'] if 'overdrawn' in akahu_account['balance'] else None,
         connection_name=akahu_account['connection']['name'],
         connection_logo=akahu_account['connection']['logo'],
-        connection_type=akahu_account['connection']['connection_type'],
-        refreshed=akahu_account['refreshed'],
-        refresh_attempt=datetime.now(tz=timezone.utc),  # Our refresh attempt
+
         user=user,
         account=account,
     )
@@ -94,9 +229,7 @@ def akahu_account_to_domain(
 
 
 def akahu_merchant_to_domain(
-        tx,
-        *,
-        merchant: Merchant | None = None,
+        tx
 ) -> AkahuMerchant:
     akahu_merchant = tx['merchant']
     return AkahuMerchant(

--- a/FlaskApp/routes/akahu/presentation.py
+++ b/FlaskApp/routes/akahu/presentation.py
@@ -1,0 +1,40 @@
+from FlaskApp.domainmodel import AkahuAccount, Account
+from FlaskApp.infra.presentation import format_cents
+from FlaskApp.routes.accounts.presentation import account_domain_to_json
+
+def akahu_account_domain_to_json(
+        akahu_account: AkahuAccount
+):
+    return {
+        "id": akahu_account.id,
+        "authorisation": akahu_account.authorisation,
+        "meta": akahu_account.meta,
+        "connection_id": akahu_account.connection_id,
+        "connection_type": akahu_account.connection_type,
+        "refreshed": {k: v.isoformat() for k, v in akahu_account.refreshed.items()},
+        "refresh_attempt": akahu_account.refresh_attempt.isoformat(),
+
+        # Similar field to accounts
+        "name": akahu_account.name,
+        "type": akahu_account.type,
+        "formatted_account": akahu_account.formatted_account,
+        "attributes": akahu_account.attributes,
+        "currency": akahu_account.currency,
+        "current_balance": format_cents(akahu_account.current_balance), # Stored as dollars
+        "available_balance": format_cents(akahu_account.available_balance) if akahu_account.available_balance is not None else None,
+        "status": akahu_account.status,
+        "created": akahu_account.created.isoformat(),
+        "credit_limit": format_cents(akahu_account.credit_limit) if akahu_account.credit_limit is not None else None,
+        "overdrawn": akahu_account.overdrawn,
+        "connection_name": akahu_account.connection_name,
+        "connection_logo": akahu_account.connection_logo,
+    }
+
+def compare_akahu_account_domain_to_json(
+    akahu_account: AkahuAccount,
+    account: Account
+):
+    return {
+        'akahu_account': akahu_account_domain_to_json(akahu_account),
+        'spendly_account': account_domain_to_json(account)
+    }

--- a/FlaskApp/routes/akahu/services.py
+++ b/FlaskApp/routes/akahu/services.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timezone
+import uuid
 
 import requests
 
-from FlaskApp.domainmodel import Transaction, Account, ExternalIdentity, User
+from FlaskApp.domainmodel import Account, ExternalIdentity, User, AkahuTransaction, Transaction,AkahuAccount
 from FlaskApp.infra.unit_of_work import AbstractUnitOfWork
-from FlaskApp.routes.akahu.assemblers import akahu_transaction_to_domain, akahu_account_to_domain, \
+from FlaskApp.routes.akahu.assemblers import akahu_pending_transaction_to_domain, akahu_transaction_to_domain, akahu_account_to_domain, \
     akahu_merchant_to_domain, akahu_category_to_domain
 from FlaskApp.infra.exceptions import ValidationError
 
@@ -69,17 +70,24 @@ def sync_akahu(
 
     akahu_accounts = client.get_accounts()
     akahu_transactions = client.get_transactions(full_sync=full_sync)
+    akahu_pending_transactions = client.get_pending_transactions()
 
     with uow:
         # Accounts
+        accounts_for_balancing: list[uuid.UUID] = []
         for acc in akahu_accounts:
             uow.akahu_accounts.log_refresh_attempt(acc['_id'], user=user)  # Not included in update function
 
             # Source exisitng account ID
-            existing_account: Account | None = uow.akahu_accounts.get_connected_account_by_id(acc['_id'], user=user)
+            existing_akahu_account: AkahuAccount | None = uow.akahu_accounts.get(acc['_id'], user=user)
 
             account, akahu_account = akahu_account_to_domain(acc, user=user,
-                                                             existing_account=existing_account)
+                                                             existing_akahu_account=existing_akahu_account)
+
+            # Must be done after transactions. Akahu balance = sum of transactions + Missing transactions (Akahu holds only 1 year before sign-up)
+            if not existing_akahu_account:
+                accounts_for_balancing.append(akahu_account.id)
+
             uow.accounts.add_or_update(account, user=user)
             uow.akahu_accounts.add_or_update(akahu_account, user=user)
 
@@ -110,14 +118,12 @@ def sync_akahu(
             category = None
 
             # Source existing transaction by Akahu transaction ID
-            existing_transaction: Transaction | None = uow.akahu_transactions.get_connected_transaction_by_id(tx['_id'],
-                                                                                                              user=user)
+            existing_transaction: AkahuTransaction | None = uow.akahu_transactions.get(tx['_id'], user=user)
 
             # Transaction
             transaction, akahu_transaction = akahu_transaction_to_domain(
                 akahu_tx=tx,
-                is_pending=False,  # This endpointpoint does not consider pending transaction.
-                existing_transaction=existing_transaction,
+                existing_akahu_transaction=existing_transaction,
                 user=user,
                 account=account,
                 akahu_account=akahu_account,
@@ -129,6 +135,57 @@ def sync_akahu(
 
             uow.transactions.add_or_update(transaction, user=user)
             uow.akahu_transactions.add_or_update(akahu_transaction, user=user)
+
+        # Remove all pending transactions that are not user enforced
+        # Hard delete since this data is considered volatile, with no definitve 'already imported' state, cannot be updated
+        uow.akahu_transactions.delete_all_pending_transactions(user=user)
+
+        # Pending Transactions
+        for tx in akahu_pending_transactions:
+            akahu_account = uow.akahu_accounts.get(tx['_account'], user=user)
+            if not akahu_account:
+                raise Exception(f"Akahu Account not found")
+            account = akahu_account.account
+
+            # Transaction
+            transaction, akahu_transaction = akahu_pending_transaction_to_domain(
+                akahu_tx=tx,
+                user=user,
+                account=account,
+                akahu_account=akahu_account,
+            )
+
+            uow.transactions.add(transaction)
+            uow.akahu_transactions.add(akahu_transaction)
+
+        for account_id in accounts_for_balancing:
+            balance_akahu_account(uow=uow, akahu_account_id=account_id, user=user)
+
+
+def balance_akahu_account(uow: AbstractUnitOfWork, akahu_account_id: str, user: User):
+    akahu_account = uow.akahu_accounts.get(akahu_account_id, user=user)
+    account = akahu_account.account
+
+    # Rebalance account balance based on sum of transactions
+    balancing_amount = akahu_account.current_balance - account.current_balance
+    balancing_transaction = Transaction(
+        transaction_id=uuid.uuid4(),
+        amount=balancing_amount, # Convert back to cents for transaction amount
+        date=datetime.now(tz=timezone.utc),
+        description="SYSTEM BALANCE ADJUSTMENT",
+        balance=None,
+        pending=False,
+        transaction_type=None,
+        status='hidden_active',
+        created=datetime.now(tz=timezone.utc),
+        latitude=None,
+        longitude=None,
+        category=None,
+        account=account,
+        merchant=None,
+        user=user
+    )
+    uow.transactions.add(balancing_transaction)
 
 
 class AkahuClient:
@@ -154,7 +211,7 @@ class AkahuClient:
         if not response.ok:
             raise Exception(f"Error fetching accounts: {data.get('message', 'Unknown error')}")
 
-        return data.get("items", [])
+        return data.get("items")
 
     def get_transactions(self, full_sync: bool = False):
         headers = self._get_headers()
@@ -184,6 +241,20 @@ class AkahuClient:
                 break
         return transactions
 
+    def get_pending_transactions(self):
+        headers = self._get_headers()
+
+        response = requests.get(
+            f"{self.base_url}/transactions/pending",
+            headers=headers
+        )
+        data = response.json()
+
+        if not response.ok:
+            raise Exception(f"Error fetching pending transactions: {data.get('message', 'Unknown error')}")
+
+        return data.get("items")
+
     def get_me(self):
         headers = self._get_headers()
 
@@ -197,3 +268,13 @@ class AkahuClient:
             raise ValidationError(f"Invalid Akahu credentials ({data.get('message', 'Unknown error')})")
 
         return data.get("item")
+
+def get_akahu_accounts(
+        uow: AbstractUnitOfWork,
+        user: User,
+        compare: bool
+):
+    with uow:
+        akahu_accounts = uow.akahu_accounts.list_akahu_accounts(user=user)
+        response = {akahu_account: akahu_account.account for akahu_account in akahu_accounts} if compare else akahu_accounts
+        return response

--- a/FlaskApp/routes/categories/categories.py
+++ b/FlaskApp/routes/categories/categories.py
@@ -1,11 +1,13 @@
 from http import HTTPStatus
+import re
 
 from flask import request, g
 from flask_restx import Resource, Namespace, fields
 
+from FlaskApp.domainmodel.category import CategoryType
 from FlaskApp.infra.db import SessionLocal
 from FlaskApp.infra.models import NullableString
-from FlaskApp.infra.services import CREATED_RESPONSE, OK_RESPONSE, make_ok_response, models
+from FlaskApp.infra.services import CREATED_RESPONSE, OK_RESPONSE, make_ok_response, models, validate_uuid
 from FlaskApp.infra.services import require_auth
 from FlaskApp.infra.unit_of_work import SqlAlchemyUnitOfWork
 from FlaskApp.routes.categories.presentation import category_domain_to_json
@@ -25,7 +27,7 @@ category_item_model = ns.model('CategoryItem', {
     'parent_category_id': NullableString(required=True, description='ID of the parent category, if any', example="")
 })
 
-new_category_item_model = ns.model('NewCategoryItem', {
+editable_category_item_model = ns.model('EditableCategoryItem', {
     'name': fields.String(required=True, description='Category name', example="Groceries"),
     'description': fields.String(required=True, description='Category description', example="Monthly grocery expenses"),
     'colour': fields.String(required=True, description='Category colour in hex code', example="#FF5733"),
@@ -34,16 +36,22 @@ new_category_item_model = ns.model('NewCategoryItem', {
     'parent_category_id': NullableString(required=True, description='ID of the parent category, if any', example=None)
 })
 
+def validate_editable_category(data):
+    if data['parent_category_id'] is not None:
+        validate_uuid(data['parent_category_id'])
+    if not data['type'] in CategoryType._value2member_map_:
+        raise ValueError(f"Invalid category type: {data['type']}. Must be one of: {[e.value for e in CategoryType]}")
+    if re.match(r'^#[0-9A-Fa-f]{6}$', data['colour']) is None:
+        raise ValueError(f"Invalid colour: {data['colour']}. Must be a hex code in the format #RRGGBB.")
+    if len(data['name']) > 100:
+        raise ValueError("Name must be 100 characters or less.")
+    if len(data['description']) > 255:
+        raise ValueError("Description must be 255 characters or less.")
+
 category_model = ns.model('Category', {
     "success": fields.Boolean(description='Indicates if the request was successful', example=True),
     "categories": fields.List(fields.Nested(category_item_model))
 })
-
-category_id_model = ns.model('category_id', {
-    'id': fields.String(required=True, description='The unique identifier of a category',
-                        example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
-})
-
 
 # endregion
 
@@ -61,38 +69,62 @@ class Category(Resource):
         return make_ok_response(categories=categories_json)
 
     @ns.response(HTTPStatus.CREATED, 'OK', models['OK'])
-    @ns.expect(new_category_item_model, validate=True)
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.expect(editable_category_item_model, validate=True)
     @require_auth(ns=ns)
     def post(self):
         """Create a new category."""
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
         data = request.get_json()
+        validate_editable_category(data)
+        # Validate
+        if data['parent_category_id'] is not None:
+            validate_uuid(data['parent_category_id'])
+
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
         create_category(uow=uow, user=g.current_user, **data)
         return CREATED_RESPONSE
 
+
+
+
+@ns.route('/<string:category_id>')
+class CategoryById(Resource):
     @ns.response(HTTPStatus.OK, 'OK', models['OK'])
-    @ns.expect(category_item_model, validate=True)
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.param('category_id', 'The unique identifier of the category to update', required=True, example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
+    @ns.expect(editable_category_item_model, validate=True)
     @ns.doc(
         description="Update an existing category. All fields are required, even if not being updated. To change the "
                     "parent category, set parent_category_id to the new parent category ID or null to remove the "
                     "parent category.")
     @require_auth(ns=ns)
-    def put(self):
+    def put(self, category_id):
         """Update an existing category."""
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
         data = request.get_json()
-        update_category(uow=uow, user=g.current_user, **data)
+
+        # Validate
+        validate_uuid(category_id)
+        validate_editable_category(data)
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        update_category(uow=uow, user=g.current_user, category_id=category_id, **data)
         return OK_RESPONSE
 
     @ns.response(HTTPStatus.OK, 'OK', models['OK'])
-    @ns.expect(category_id_model, validate=True)
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.param('category_id', 'The unique identifier of the category to delete', required=True, example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
     @ns.doc(
         description="Delete an existing category. If the category has any transactions associated with it, the "
                     "category of those transactions will be set to null.")
     @require_auth(ns=ns)
-    def delete(self):
+    def delete(self, category_id):
         """Delete an existing category."""
+
+        # Validate
+        validate_uuid(category_id)
+
         uow = SqlAlchemyUnitOfWork(SessionLocal)
-        data = request.get_json()
-        delete_category(uow=uow, user=g.current_user, category_id=data['id'])
+
+        delete_category(uow=uow, user=g.current_user, category_id=category_id)
         return OK_RESPONSE

--- a/FlaskApp/routes/categories/services.py
+++ b/FlaskApp/routes/categories/services.py
@@ -13,8 +13,8 @@ def get_categories(uow: AbstractUnitOfWork, user: User) -> list[Category]:
 def create_category(uow: AbstractUnitOfWork, user: User, name: str, description: str, colour: str, icon: str | None, type: str, parent_category_id: str | None):
     # TODO: Category type validation
     with uow:
-        parent_category = uow.categories.get(parent_category_id)
-        if not parent_category_id and not parent_category:
+        parent_category = uow.categories.get(parent_category_id, user=user) if parent_category_id else None
+        if parent_category_id and not parent_category:
             raise Exception("Parent category not found")
         category = Category(
             category_id=uuid4(),
@@ -29,12 +29,12 @@ def create_category(uow: AbstractUnitOfWork, user: User, name: str, description:
         )
         uow.categories.add(category)
 
-def update_category(uow: AbstractUnitOfWork, user: User, id: str, name: str, description: str, colour: str, icon: str | None, type: str, parent_category_id: str | None):
+def update_category(uow: AbstractUnitOfWork, user: User, category_id: str, name: str, description: str, colour: str, icon: str | None, type: str, parent_category_id: str | None):
     # TODO: Category type validation
     parent_category_id = parent_category_id if parent_category_id else None
     parent_category = None
     with uow:
-        category = uow.categories.get(id, user=user)
+        category = uow.categories.get(category_id, user=user)
         if not category:
             raise Exception("Category not found")
         if parent_category_id:

--- a/FlaskApp/routes/transactions/presentation.py
+++ b/FlaskApp/routes/transactions/presentation.py
@@ -1,13 +1,14 @@
-from FlaskApp.domainmodel import Transaction, Upload
+from FlaskApp.domainmodel import Transaction
+from FlaskApp.infra.presentation import format_cents
 
 
 def transaction_domain_to_json(transaction: Transaction) -> dict:
     return {
         "id": str(transaction.id),
-        "amount": str(transaction.amount),
+        "amount": format_cents(transaction.amount),  # Convert cents to dollars
         "date": transaction.date.isoformat(),
         "description": transaction.description,
-        "balance": str(transaction.balance),
+        "balance": format_cents(transaction.balance) if transaction.balance is not None else None,
         "pending": transaction.pending,
         'type': transaction.type,
         'status': transaction.status,
@@ -17,14 +18,4 @@ def transaction_domain_to_json(transaction: Transaction) -> dict:
         "category_id": str(transaction.category.id) if transaction.category else None,
         "account_id": str(transaction.account.id),
         "merchant_id": str(transaction.merchant.id) if transaction.merchant else None
-    }
-
-
-def upload_domain_to_json(upload: Upload) -> dict:
-    return {
-        "id": str(upload.id),
-        "filename": upload.file_name,
-        "bank": upload.bank,
-        "created": upload.created.isoformat(),
-        "transaction_count": len(upload.transaction_ids)
     }

--- a/FlaskApp/routes/transactions/services.py
+++ b/FlaskApp/routes/transactions/services.py
@@ -2,23 +2,23 @@ import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
 
-import pandas as pd
-from werkzeug.datastructures import FileStorage
-
-from FlaskApp.domainmodel import Transaction, Upload, User
-from FlaskApp.infra.exceptions import AppError
+from FlaskApp.domainmodel import Transaction, User
+from FlaskApp.infra.services import to_amount_cents
 from FlaskApp.infra.unit_of_work import AbstractUnitOfWork
-from FlaskApp.routes.transactions.assemblers import upload_csv_anz, upload_csv_kiwibank
 
 
 def get_transactions(uow: AbstractUnitOfWork, user: User, **filters):
     with uow:
+        if filters.get('start_amount'):
+            filters['start_amount'] = to_amount_cents(filters['start_amount'])
+        if filters.get('end_amount'):
+            filters['end_amount'] = to_amount_cents(filters['end_amount'])
         transactions = uow.transactions.get_with_filters(user=user, **filters)
         return transactions
 
 
-def create_transaction(uow: AbstractUnitOfWork, user: User, amount: Decimal, date: str, description: str | None,
-                       balance: float | None, pending: bool | None, type: str | None, latitude: float | None,
+def create_transaction(uow: AbstractUnitOfWork, user: User, amount: str, date: str, description: str | None,
+                       balance: str | None, pending: bool | None, type: str | None, latitude: float | None,
                        longitude: float | None, category_id: str | None, account_id: str, merchant_id: str | None):
     with uow:
         account = uow.accounts.get(account_id, user=user)
@@ -28,10 +28,10 @@ def create_transaction(uow: AbstractUnitOfWork, user: User, amount: Decimal, dat
         merchant = uow.merchants.get(merchant_id, user=user) if merchant_id else None
         transaction = Transaction(
             transaction_id=uuid.uuid4(),
-            amount=amount,
+            amount=to_amount_cents(amount),
             date=datetime.fromisoformat(date),
             description=description,
-            balance=balance,
+            balance=to_amount_cents(balance) if balance is not None else None,
             pending=pending,
             transaction_type=type,
             status='active',
@@ -46,13 +46,13 @@ def create_transaction(uow: AbstractUnitOfWork, user: User, amount: Decimal, dat
         uow.transactions.add(transaction)
 
 
-def update_transaction(uow: AbstractUnitOfWork, user: User, id: str, amount: Decimal, date: str,
-                       description: str | None, balance: float | None, pending: bool, type: str | None, status: str,
+def update_transaction(uow: AbstractUnitOfWork, user: User, transaction_id: str, amount: str, date: str,
+                       description: str | None, balance: str | None, pending: bool, type: str | None,
                        latitude: float | None, longitude: float | None, category_id: str | None, account_id: str,
-                       merchant_id: str | None, created: str):
+                       merchant_id: str | None):
     with uow:
-        exists = uow.transactions.exists(id, user=user)
-        if not exists:
+        transaction = uow.transactions.get(transaction_id, user=user)
+        if transaction is None:
             raise Exception("Transaction not found")
         account = uow.accounts.get(account_id, user=user)
         if account is None:
@@ -60,23 +60,17 @@ def update_transaction(uow: AbstractUnitOfWork, user: User, id: str, amount: Dec
         category = uow.categories.get(category_id, user=user) if category_id else None
         merchant = uow.merchants.get(merchant_id, user=user) if merchant_id else None
 
-        transaction = Transaction(
-            transaction_id=uuid.UUID(id),
-            amount=amount,
-            date=datetime.fromisoformat(date),
-            description=description,
-            balance=balance,
-            pending=pending,
-            transaction_type=type,
-            status=status,
-            created=datetime.fromisoformat(created),
-            latitude=latitude,
-            longitude=longitude,
-            category=category,
-            account=account,
-            merchant=merchant,
-            user=user
-        )
+        transaction.amount=to_amount_cents(amount)
+        transaction.date=datetime.fromisoformat(date)
+        transaction.description=description
+        transaction.balance=to_amount_cents(balance) if balance is not None else None
+        transaction.pending=pending
+        transaction.type=type
+        transaction.latitude=latitude
+        transaction.longitude=longitude
+        transaction.category=category
+        transaction.account=account
+        transaction.merchant=merchant
 
         uow.transactions.add_or_update(transaction, user=user)
 
@@ -89,11 +83,11 @@ def delete_transaction(uow: AbstractUnitOfWork, user: User, transaction_id: str)
         uow.transactions.delete(transaction_id, user=user)
 
 
-def patch_transaction(uow: AbstractUnitOfWork, user: User, id: str, category_id: str | None = None,
+def patch_transaction(uow: AbstractUnitOfWork, user: User, transaction_id: str, category_id: str | None = None,
                       account_id: str | None = None, merchant_id: str | None = None):
     with uow:
         # Get existing transaction, service will update as only updating relationships
-        transaction = uow.transactions.get(id, user=user)
+        transaction = uow.transactions.get(transaction_id, user=user)
         if transaction is None:
             raise Exception("Transaction not found")
 
@@ -116,79 +110,6 @@ def patch_transaction(uow: AbstractUnitOfWork, user: User, id: str, category_id:
         transaction.merchant = merchant if merchant_id else transaction.merchant
 
         uow.transactions.add_or_update(transaction, user=user)
-
-
-def get_uploads(uow: AbstractUnitOfWork, user: User):
-    with uow:
-        uploads = uow.uploads.list_uploads(user=user)
-        return uploads
-
-
-def upload_csv(uow: AbstractUnitOfWork, user: User, file: FileStorage, bank: str, account_id: str):
-    df = pd.read_csv(file)
-
-    bank_parsers = {
-        "anz": upload_csv_anz,
-        "kiwibank": upload_csv_kiwibank,
-    }
-    parser = bank_parsers.get(bank)
-
-    try:
-        df = parser(df)
-    except KeyError:
-        raise AppError(f"Unexpected CSV format. Suggested fix: Check selected bank ({bank})")
-
-    with uow:
-        account = uow.accounts.get(account_id, user=user)
-        if account is None:
-            raise Exception("Account not found")
-
-        upload = Upload(
-            upload_id=uuid.uuid4(),
-            file_name=file.filename,
-            user=user,
-            transaction_ids=[],
-            status='pending',
-            bank=bank,
-            created=datetime.now(tz=timezone.utc)
-        )
-
-        for _, row in df.iterrows():
-            # TODO: Add category and merchant matching logic
-            transaction_id = uuid.uuid4()
-            upload.add_transaction(transaction_id)
-
-            transaction = Transaction(
-                transaction_id=transaction_id,
-                amount=row['amount'],
-                date=datetime.fromisoformat(row['date']),
-                description=row['description'],
-                transaction_type=row['type'],
-                status='active',
-                balance=row['balance'] if 'balance' in row else None,
-                pending=False,
-                # Currently, no supported banks have pending transactions in their CSV exports, so default to False. Can add support later if needed.
-                created=datetime.now(tz=timezone.utc),
-                latitude=None,
-                longitude=None,
-                category=None,
-                account=account,
-                merchant=None,
-                user=user,
-            )
-
-            uow.transactions.add(transaction)
-
-        uow.uploads.add(upload)
-
-
-def delete_upload(uow: AbstractUnitOfWork, user: User, upload_id: str):
-    with uow:
-        exists = uow.uploads.exists(upload_id, user=user)
-        if not exists:
-            raise Exception("Upload not found")
-        uow.uploads.delete(upload_id, user=user)
-
 
 def update_transaction_locations(uow: AbstractUnitOfWork, user: User, transaction_id: str, latitude: float,
                                  longitude: float):

--- a/FlaskApp/routes/transactions/transactions.py
+++ b/FlaskApp/routes/transactions/transactions.py
@@ -1,27 +1,22 @@
+import datetime
 import enum
 from http import HTTPStatus
+import re
 
 from flask import request, g
 from flask_restx import Resource, Namespace, fields, reqparse
-from werkzeug.datastructures import FileStorage
 
 from FlaskApp.infra.db import SessionLocal
 from FlaskApp.infra.exceptions import ValidationError
 from FlaskApp.infra.models import NullableFloat, NullableString, parse_bool, parse_bool_or_other
-from FlaskApp.infra.services import CREATED_RESPONSE, OK_RESPONSE, make_ok_response, require_auth, models
+from FlaskApp.domainmodel.transaction import TransactionType
+from FlaskApp.infra.services import CREATED_RESPONSE, OK_RESPONSE, make_ok_response, require_auth, models, validate_uuid
 from FlaskApp.infra.unit_of_work import SqlAlchemyUnitOfWork
-from FlaskApp.routes.transactions.presentation import transaction_domain_to_json, upload_domain_to_json
-from FlaskApp.routes.transactions.services import create_transaction, delete_transaction, delete_upload, \
-    get_transactions, get_uploads, update_transaction, patch_transaction, upload_csv, update_transaction_locations
+from FlaskApp.routes.transactions.presentation import transaction_domain_to_json
+from FlaskApp.routes.transactions.services import create_transaction, delete_transaction, \
+    get_transactions, update_transaction, patch_transaction, update_transaction_locations
 
 ns = Namespace('transactions', description='Operations related to transactions')
-
-
-# region Enums
-class SupportedBank(fields.String, enum.Enum):
-    ANZ = 'anz'
-    KIWIBANK = 'kiwibank'
-
 
 class SupportedSort(fields.String, enum.Enum):
     DATE = 'date'
@@ -31,41 +26,37 @@ class SupportedSort(fields.String, enum.Enum):
     CREATED = 'created'
     CREATED_DESC = '-created'
 
-
-# endregion
-
 # region Transaction Models and Parsers
 transaction_item_model = ns.model('TransactionItem', {
     'id': fields.String(readOnly=True, description='The unique identifier of a transaction',
                         example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
-    'amount': fields.Float(required=True, description='Transaction amount', example=100.50),
+    'amount': fields.String(required=True, description='Transaction amount', example='100.50'),
     'date': fields.Date(required=True, description='Transaction date', example="2024-01-01"),
     'description': fields.String(required=True, description='Transaction description', example="Grocery shopping"),
-    'balance': NullableFloat(required=True, description='Account balance after the transaction', example=1500.75),
+    'balance': NullableString(required=False, description='Account balance after the transaction', example='1500.75'),
     'pending': fields.Boolean(required=True, description='Indicates if the transaction is pending', example=False),
-    'type': NullableString(required=True, description='Transaction type', example="VISA PURCHASE"),
+    'type': NullableString(required=True, description='Transaction type', example="VISA PURCHASE", enum=[e.value for e in TransactionType]),
     'status': fields.String(required=True, description='Transaction status', example="active"),
     'created': fields.DateTime(required=True, description='Timestamp when the transaction was created',
                                example="2024-01-01T12:00:00Z"),
-    'latitude': NullableFloat(required=True, description='Latitude of the transaction location', example=-36.848378776),
-    'longitude': NullableFloat(required=True, description='Longitude of the transaction location',
+    'latitude': NullableFloat(required=False, description='Latitude of the transaction location', example=-36.848378776),
+    'longitude': NullableFloat(required=False, description='Longitude of the transaction location',
                                example=174.764381777),
-    'category_id': NullableString(required=True, description='ID of the associated category',
+    'category_id': NullableString(required=False, description='ID of the associated category',
                                   example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
     'account_id': fields.String(required=True, description='ID of the associated account',
                                 example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
-    'merchant_id': NullableString(required=True, description='ID of the associated merchant',
+    'merchant_id': NullableString(required=False, description='ID of the associated merchant',
                                   example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
 })
 
-new_transaction_model = ns.model('NewTransaction', {
-    'amount': fields.Float(required=True, description='Transaction amount', example=100.50),
+editable_transaction_item_model = ns.model('EditableTransactionItem', {
+    'amount': fields.String(required=True, description='Transaction amount', example='100.50'),
     'date': fields.Date(required=True, description='Transaction date', example="2024-01-01"),
     'description': fields.String(required=True, description='Transaction description', example="Grocery shopping"),
-    'balance': NullableFloat(required=True, description='Account balance after the transaction', example=6900.00),
-    'pending': fields.Boolean(required=True, description='Indicates if the transaction is pending', example=False,
-                              default=False),
-    'type': NullableString(required=True, description='Transaction type', example="VISA PURCHASE"),
+    'balance': NullableString(required=True, description='Account balance after the transaction', example='1500.75'),
+    'pending': fields.Boolean(required=True, description='Indicates if the transaction is pending', example=False),
+    'type': NullableString(required=True, description='Transaction type', example="VISA PURCHASE", enum=[e.value for e in TransactionType]),
     'latitude': NullableFloat(required=True, description='Latitude of the transaction location', example=-36.848378776),
     'longitude': NullableFloat(required=True, description='Longitude of the transaction location',
                                example=174.764381777),
@@ -77,9 +68,33 @@ new_transaction_model = ns.model('NewTransaction', {
                                   example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
 })
 
+def validate_transaction_editable_fields(data):
+    validate_uuid(data['category_id'], "category_id")
+    validate_uuid(data['account_id'], "account_id")
+    validate_uuid(data['merchant_id'], "merchant_id")
+    if data['type'] not in TransactionType._value2member_map_:
+        raise ValidationError(f"Invalid transaction type. Valid types: {[e.value for e in TransactionType]}")
+    if data['pending'] not in [True, False]:
+        raise ValidationError("Invalid pending value. Must be a boolean.")
+    if data['status'] not in ['active', 'deleted']:
+        raise ValidationError("Invalid status value. Must be 'active' or 'deleted'.")
+    if data['date']:
+        try:
+            datetime.fromisoformat(data['date'])
+        except ValueError:
+            raise ValidationError("Invalid date format. Must be ISO 8601 format.")
+    if not isinstance(data['latitude'], (float, int)) or not -90 <= data['latitude'] <= 90:
+        raise ValidationError("Invalid latitude value. Must be a number between -90 and 90. Decimal values should be used for coordinates.")
+    if not isinstance(data['longitude'], (float, int)) or not -180 <= data['longitude'] <= 180:
+        raise ValidationError("Invalid longitude value. Must be a number between -180 and 180. Decimal values should be used for coordinates.")
+    if not re.match(r'^\d+(\.\d{1,2})?$', data['amount']):
+        raise ValidationError("Invalid amount format. Must be a valid decimal number with up to 2 decimal places.")
+    if data['balance'] is not None and not re.match(r'^\d+(\.\d{1,2})?$', data['balance']):
+        raise ValidationError("Invalid balance format. Must be a valid decimal number with up to 2 decimal places.")
+    if len(data['description']) > 255:
+        raise ValidationError("Description is too long. Maximum length is 255 characters.")
+
 transaction_patch_model = ns.model('PatchTransaction', {
-    'id': fields.String(required=True, description='The unique identifier of a transaction',
-                        example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
     'category_id': NullableString(required=False, description='ID of the associated category',
                                   example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
     'account_id': fields.String(required=False, description='ID of the associated account',
@@ -93,13 +108,7 @@ transaction_model = ns.model('Transaction', {
     "transactions": fields.List(fields.Nested(transaction_item_model))
 })
 
-transaction_id_model = ns.model('transaction_id', {
-    'id': fields.String(required=True, description='The unique identifier of a transaction',
-                        example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
-})
-
 # Parser for GET /transactions
-
 
 get_transactions_parser = reqparse.RequestParser()
 get_transactions_parser.add_argument('start_date', type=str, required=False,
@@ -108,9 +117,9 @@ get_transactions_parser.add_argument('end_date', type=str, required=False,
                                      help='End date for filtering transactions (ISO 8601 format)')
 get_transactions_parser.add_argument('search', type=str, required=False,
                                      help='Search term to filter transactions by description. Case-insensitive substring match.')
-get_transactions_parser.add_argument('type', type=str, required=False,
+get_transactions_parser.add_argument('type', type=str, required=False, choices=[e.value for e in TransactionType],
                                      help='Filter transactions by type. Case-insensitive exact match.')
-get_transactions_parser.add_argument('pending', type=parse_bool, required=False,
+get_transactions_parser.add_argument('pending', type=parse_bool, choices=[True, False], required=False,
                                      help='Filter transactions by pending status. Boolean.')
 get_transactions_parser.add_argument('status', type=str, required=False, default='active',
                                      choices=['active', 'deleted'], help="Filter transactions by status.")
@@ -120,9 +129,9 @@ get_transactions_parser.add_argument('account_id', type=str, required=False,
                                      help='Account ID for filtering transactions.')
 get_transactions_parser.add_argument('merchant_id', type=lambda x: parse_bool_or_other(x, str), required=False,
                                      help='Merchant ID for filtering transactions. Boolean indicates existence filter.')
-get_transactions_parser.add_argument('start_amount', type=float, required=False,
+get_transactions_parser.add_argument('start_amount', type=str, required=False,
                                      help='Minimum amount for filtering transactions.')
-get_transactions_parser.add_argument('end_amount', type=float, required=False,
+get_transactions_parser.add_argument('end_amount', type=str, required=False,
                                      help='Maximum amount for filtering transactions.')
 get_transactions_parser.add_argument('start_lat', type=lambda x: parse_bool_or_other(x, float), required=False,
                                      help='Minimum latitude for filtering transactions. Boolean indicates existence filter. No end_lat provided means exact match.')
@@ -138,37 +147,6 @@ get_transactions_parser.add_argument('per_page', type=int, required=False, defau
 get_transactions_parser.add_argument('sort', type=str, required=False, default='-date',
                                      choices=[e.value for e in SupportedSort],
                                      help=f"Field to sort by. Prefix with '-' for descending order.")
-
-
-# endregion
-
-# region Upload Models and Parsers
-upload_id_model = ns.model('upload_id', {
-    'id': fields.String(required=True, description='The unique identifier of a upload',
-                        example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
-})
-
-upload_transaction_model = ns.model('UploadTransactionResponse', {
-    "success": fields.Boolean(description='Indicates if the request was successful', example=True),
-    "uploads": fields.List(fields.Nested(ns.model('UploadItem', {
-        'id': fields.String(readOnly=True, description='The unique identifier of an upload',
-                            example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"),
-        'filename': fields.String(description='Original filename of the uploaded CSV file', example="transactions.csv"),
-        'bank': fields.String(description='Bank associated with the uploaded transactions', example="ANZ"),
-        'created': fields.DateTime(description='Timestamp when the file was uploaded', example="2024-01-01T12:00:00Z"),
-        'transaction_count': fields.Integer(description='Number of transactions associated with the upload',
-                                            example=100),
-    })))
-})
-
-# Parsers for POST /transactions/upload
-upload_csv_parser = ns.parser()
-upload_csv_parser.add_argument('file', location='files', type=FileStorage, required=True)
-upload_csv_parser.add_argument('bank', location='form', type=str, choices=[bank.value for bank in SupportedBank],
-                               help=f'Bank associated with the uploaded transactions.', required=True)
-upload_csv_parser.add_argument('account_id', location='form', type=str,
-                               help='ID of the account to associate the uploaded transactions with. Example: "a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4"',
-                               required=True)
 
 # endregion
 
@@ -189,6 +167,7 @@ transaction_map_model = ns.model('TransactionMap', {
 class Transaction(Resource):
 
     @ns.response(HTTPStatus.OK, 'OK', transaction_model)
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
     @ns.expect(get_transactions_parser, validate=True)
     @ns.doc(
         description="Get a list of transactions with optional filters. By default, only active transactions are returned in date descending order. All filters are optional and can be combined. Pagination and sorting are supported.")
@@ -198,124 +177,141 @@ class Transaction(Resource):
         uow = SqlAlchemyUnitOfWork(SessionLocal)
         args = get_transactions_parser.parse_args()
         filters = {k: v for k, v in args.items() if v is not None}
+
+        # Validation for filters
+        try:
+            if 'start_date' in filters:
+                filters['start_date'] = datetime.fromisoformat(filters['start_date'])
+            if 'end_date' in filters:
+                filters['end_date'] = datetime.fromisoformat(filters['end_date'])
+        except ValueError:
+            raise ValidationError(f"Invalid date format. Dates must be in ISO 8601 format.")
+        if 'start_amount' in filters and not re.match(r'^\d+(\.\d{1,2})?$', filters['start_amount']):
+            raise ValidationError("Invalid start_amount format. Must be a valid decimal number with up to 2 decimal places.")
+        if 'end_amount' in filters and not re.match(r'^\d+(\.\d{1,2})?$', filters['end_amount']):
+            raise ValidationError("Invalid end_amount format. Must be a valid decimal number with up to 2 decimal places.")
+        if 'start_lat' in filters:
+            val=filters['start_lat']
+            if isinstance(val, (float, int)):
+                if not -90 <= val <= 90:
+                    raise ValidationError("Invalid start_lat value. Must be a number between -90 and 90. Decimal values should be used for coordinates.")
+            elif isinstance(val, (bool)):
+                raise ValidationError("Invalid start_lat value. May be a float, int, or boolean for latitude existence filter.")
+        if 'end_lat' in filters and (not isinstance(filters['end_lat'], (float, int)) or not -90 <= filters['end_lat'] <= 90):
+            raise ValidationError("Invalid end_lat value. Must be a number between -90 and 90. Decimal values should be used for coordinates.")
+        if 'start_lng' in filters:
+            val=filters['start_lng']
+            if isinstance(val, (float, int)):
+                if not -180 <= val <= 180:
+                    raise ValidationError("Invalid start_lng value. Must be a number between -180 and 180. Decimal values should be used for coordinates.")
+            elif isinstance(val, (bool)):
+                raise ValidationError("Invalid start_lng value. May be a float, int, or boolean for longitude existence filter.")
+        if 'end_lng' in filters and (not isinstance(filters['end_lng'], (float, int)) or not -180 <= filters['end_lng'] <= 180):
+            raise ValidationError("Invalid end_lng value. Must be a number between -180 and 180. Decimal values should be used for coordinates.")
+
+
         transactions = get_transactions(uow=uow, user=g.current_user, **filters)
         transactions_json = [transaction_domain_to_json(transaction) for transaction in transactions]
         return make_ok_response(transactions=transactions_json)
 
     @ns.response(HTTPStatus.CREATED, 'OK', models['OK'])
-    @ns.expect(new_transaction_model, validate=True)
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.expect(editable_transaction_item_model, validate=True)
     @ns.doc(
         description="Create a new transaction. All fields are required. If the transaction is not associated with a category or merchant, set category_id or merchant_id to null.")
     @require_auth(ns=ns)
     def post(self):
         """Create a new transaction."""
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
+
+        # Validation
         data = request.get_json()
+        validate_transaction_editable_fields(data)
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
         create_transaction(uow=uow, user=g.current_user, **data)
         return CREATED_RESPONSE
 
+
+@ns.route('/<string:transaction_id>')
+class TransactionByID(Resource):
+
     @ns.response(HTTPStatus.OK, 'OK', models['OK'])
-    @ns.expect(transaction_item_model, validate=True)
-    @ns.doc(
-        description="Update an existing transaction. All fields are required, even if not being updated. Use the PATCH endpoint to update only category, merchant, or account relationships.")
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.expect(editable_transaction_item_model, validate=True)
+    @ns.param('transaction_id', description='The unique identifier of the transaction', example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
+    @ns.doc(description="Update an existing transaction. All fields are required, even if not being updated. Use the PATCH endpoint to update only category, merchant, or account relationships.")
     @require_auth(ns=ns)
-    def put(self):
-        # TODO: Currently akahu transactions do not persist updates between syncs
+    def put(self, transaction_id):
         """Update an existing transaction."""
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
         data = request.get_json()
-        update_transaction(uow=uow, user=g.current_user, **data)
+
+        # Validation
+        validate_uuid(transaction_id, "transaction_id")
+        validate_transaction_editable_fields(data)
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        update_transaction(uow=uow, user=g.current_user, transaction_id=transaction_id, **data)
         return OK_RESPONSE
 
     @ns.response(HTTPStatus.OK, 'OK', models['OK'])
-    @ns.expect(transaction_id_model, validate=True)
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
+    @ns.param('transaction_id', description='The unique identifier of the transaction', example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
+    @ns.doc(description="Delete an existing transaction. This will set the transaction's status to 'deleted' (soft delete) and it will no longer be returned in the default GET /transactions endpoint.")
     @require_auth(ns=ns)
-    def delete(self):
-        # TODO: Currently akahu transactions do not persist deletions between syncs
+    def delete(self, transaction_id):
         """Delete an existing transaction."""
+
+        # Validation
+        validate_uuid(transaction_id, "transaction_id")
+
         uow = SqlAlchemyUnitOfWork(SessionLocal)
-        data = request.get_json()
-        delete_transaction(uow=uow, user=g.current_user, transaction_id=data['id'])
+        delete_transaction(uow=uow, user=g.current_user, transaction_id=transaction_id)
         return OK_RESPONSE
 
     @ns.response(HTTPStatus.OK, 'OK', models['OK'])
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
     @ns.expect(transaction_patch_model, validate=True)
+    @ns.param('transaction_id', description='The unique identifier of the transaction', example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
     @ns.doc(
         description="Update the category, merchant, or account of an existing transaction. This is intended for updating relationships only, use the PUT endpoint to update other transaction fields.")
     @require_auth(ns=ns)
-    def patch(self):
+    def patch(self, transaction_id):
         """Update category, merchant, or account of an existing transaction."""
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
         data = request.get_json()
-        patch_transaction(uow=uow, user=g.current_user, **data)
+
+        # Validation
+        validate_uuid(transaction_id, "transaction_id")
+        if 'category_id' in data:
+            validate_uuid(data['category_id'], "category_id")
+        if 'account_id' in data:
+            validate_uuid(data['account_id'], "account_id")
+        if 'merchant_id' in data:
+            validate_uuid(data['merchant_id'], "merchant_id")
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        patch_transaction(uow=uow, user=g.current_user, transaction_id=transaction_id, **data)
         return OK_RESPONSE
 
 
-@ns.route('/upload')
-class CSVUpload(Resource):
-
-    @ns.response(HTTPStatus.OK, 'OK', upload_transaction_model)
-    @ns.doc(
-        description="Get a list of uploaded CSV files. This will include metadata about the upload but not the transactions themselves.")
-    @require_auth(ns=ns)
-    def get(self):
-        """Get a list of uploaded CSV files."""
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
-        uploads = get_uploads(uow=uow, user=g.current_user)
-        uploads_json = [upload_domain_to_json(upload) for upload in uploads]
-        return {"success": True, "uploads": uploads_json}, HTTPStatus.OK
-
-    @ns.response(HTTPStatus.CREATED, 'OK', models['OK'])
-    @ns.response(HTTPStatus.BAD_REQUEST, 'Bad Request', models['BadRequest'])
-    @ns.expect(upload_csv_parser, validate=True)
-    @ns.doc(
-        description="Upload a CSV file of transactions. Supported banks: ANZ, Kiwibank. CSV format must match the format provided by the bank's online transaction export.")
-    @require_auth(ns=ns)
-    def post(self):
-        """Upload a CSV file of transactions."""
-        args = upload_csv_parser.parse_args()
-        file = args.get('file')
-        bank = args.get('bank')
-        account_id = args.get('account_id')
-        if not file:
-            raise ValidationError("No file provided")
-        filename = file.filename.lower()
-        if not (filename.endswith('.csv')):
-            raise ValidationError("Unsupported file format. Only CSV files are supported.")
-        if not bank.lower() in [bank.value for bank in SupportedBank]:
-            raise ValidationError(f"Unsupported bank. Supported banks: {[bank.value for bank in SupportedBank]}")
-
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
-        upload_csv(uow=uow, file=file, user=g.current_user, bank=bank, account_id=account_id)
-        return CREATED_RESPONSE
-
-    @ns.response(HTTPStatus.OK, 'OK', models['OK'])
-    @ns.expect(upload_id_model, validate=True)
-    @ns.doc(
-        description="Delete an uploaded CSV file of transactions. This will delete any transactions that were created from the upload.")
-    @require_auth(ns=ns)
-    def delete(self):
-        """Delete an uploaded CSV file of transactions."""
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
-        data = request.get_json()
-        delete_upload(uow=uow, user=g.current_user, upload_id=data['id'])
-        return OK_RESPONSE
-
-
-@ns.route('/map')
+@ns.route('/<string:transaction_id>/map')
 class TransactionMap(Resource):
 
     @ns.response(HTTPStatus.OK, 'OK', models['OK'])
+    @ns.response(HTTPStatus.BAD_REQUEST, 'Validation Error', models['BadRequest'])
     @ns.expect(transaction_map_model, validate=True)
+    @ns.param('transaction_id', description='The unique identifier of the transaction', example="a1b2c3d4-e5f6-a1b2-c3d4-e5f6a1b2c3d4")
     @ns.doc(
         description="Get a list of transactions with latitude and longitude for mapping. Only transactions with valid latitude and longitude will be returned.")
     @require_auth(ns=ns)
-    def post(self):
+    def post(self, transaction_id):
         """Update an existing transaction's latitude and longitude."""
-        uow = SqlAlchemyUnitOfWork(SessionLocal)
         data = request.get_json()
 
-        update_transaction_locations(uow=uow, user=g.current_user, transaction_id=data['id'], latitude=data['latitude'],
+        # Validation
+        validate_uuid(transaction_id, "transaction_id")
+
+        uow = SqlAlchemyUnitOfWork(SessionLocal)
+        update_transaction_locations(uow=uow, user=g.current_user, transaction_id=transaction_id, latitude=data['latitude'],
                                      longitude=data['longitude'])
 
         return OK_RESPONSE

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests
 flask_cors
 sqlalchemy
 werkzeug
+iso4217


### PR DESCRIPTION
- Added new routes for managing accounts.
- Added global utils for managing common request/response operations and documentation.
- Moved upload services into account to maintain RESTful designs.
- Upgraded akahu namepsace with account routes.
- Updated akahu tables to store all imported data, this allows comparison later of our mutated data and the original for reconciliation if needed.

Added validation to all routes with incoming data to meet expected format. Updated domain model to extend a validation base, and updated all mutable fields to use setter methods. Immutable fields validate on initialisation.

SPEND-31